### PR TITLE
Implemented a safer version of exec_command_in_pod

### DIFF
--- a/src/krkn_lib/tests/base_test.py
+++ b/src/krkn_lib/tests/base_test.py
@@ -101,6 +101,12 @@ class BaseTest(unittest.TestCase):
         template = self.template_to_job(name, namespace)
         self.apply_template(template)
 
+    def depoy_alpine(self, name: str, namespace: str = "default"):
+        environment = Environment(loader=FileSystemLoader("src/testdata/"))
+        template = environment.get_template("alpine.j2")
+        content = template.render(name=name, namespace=namespace)
+        self.apply_template(content)
+
     def deploy_persistent_volume(
         self, name: str, storage_class: str, namespace: str
     ):

--- a/src/krkn_lib/tests/test_krkn_kubernetes.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes.py
@@ -19,7 +19,7 @@ from tzlocal import get_localzone
 
 
 class KrknKubernetesTests(BaseTest):
-    def test_exec_command_unsafe(self):
+    def test_exec_command(self):
         namespace = "test-ns-" + self.get_random_string(10)
         alpine_name = "alpine-" + self.get_random_string(10)
         self.deploy_namespace(namespace, [])

--- a/src/testdata/alpine.j2
+++ b/src/testdata/alpine.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ name }}
+  namespace: {{ namespace }}
+spec:
+  containers:
+  - image: alpine
+    command:
+      - /bin/sh
+      - "-c"
+      - "sleep 60m"
+    imagePullPolicy: IfNotPresent
+    name: alpine
+  restartPolicy: Always


### PR DESCRIPTION
This is not a breaking change since the method signature didn't change, it adds simply a fallback on `/bin/sh` whenever the base_command is `None` and `/bin/bash` is not available in the container