### PR TITLE
Adding no range option for prometheus queries

### DIFF
--- a/src/krkn_lib/prometheus/krkn_prometheus.py
+++ b/src/krkn_lib/prometheus/krkn_prometheus.py
@@ -34,7 +34,7 @@ class KrknPrometheus:
             logging.error("Not able to initialize the client %s" % e)
             sys.exit(1)
 
-    # Process custom prometheus query
+    # Process custom prometheus query with time range
     def process_prom_query_in_range(
         self,
         query: str,
@@ -42,7 +42,8 @@ class KrknPrometheus:
         end_time: datetime = None,
     ) -> list[dict[str:any]]:
         """
-        Executes a query to the Prometheus API in PromQL language
+        Executes a query to the Prometheus API in PromQL languag,
+        between a start and end time
 
         :param query: promQL query
         :param start_time: start time of the result set (default now - 1 day)
@@ -69,6 +70,32 @@ class KrknPrometheus:
                     end_time=end_time,
                     step=f"{granularity}s",
                 )
+            except Exception as e:
+                logging.error("Failed to get the metrics: %s" % e)
+                raise e
+        else:
+            logging.info(
+                "Skipping the prometheus query as the "
+                "prometheus client couldn't "
+                "be initialized\n"
+            )
+
+    # Process custom prometheus query
+    def process_query(
+        self,
+        query: str
+    ) -> list[dict[str:any]]:
+        """
+        Executes a query to the Prometheus API in PromQL language
+
+        :param query: promQL query
+
+        :return: a list of records in dictionary format
+        """
+        
+        if self.prom_cli:
+            try: 
+                return self.prom_cli.custom_query(query=query)
             except Exception as e:
                 logging.error("Failed to get the metrics: %s" % e)
                 raise e

--- a/src/krkn_lib/tests/test_krkn_prometheus.py
+++ b/src/krkn_lib/tests/test_krkn_prometheus.py
@@ -22,9 +22,21 @@ class TestKrknPrometheus(BaseTest):
         for value in res[0]["values"]:
             self.assertEqual(len(value), 2)
 
+    def process_query(self):
+        prom_cli = KrknPrometheus(self.url)
+        query = "node_boot_time_seconds"
+
+        res = prom_cli.process_query(query)
+
+        self.assertTrue(len(res) > 0)
+        self.assertTrue("metric" in res[0].keys())
+        self.assertTrue("values" in res[0].keys())
+        for value in res[0]["values"]:
+            self.assertEqual(len(value), 2)
+
     def test_process_alert(self):
         prom_cli = KrknPrometheus(self.url)
-        res = prom_cli.process_prom_query_in_range("node_boot_time_seconds")
+        res = prom_cli.process_prom_query_in_range("node_boot_time_seconds", end_time=datetime.datetime.now())
         logging.disable(logging.NOTSET)
         controls = []
         for result in res:


### PR DESCRIPTION
For critical alerts, dont want to look at any past alerts that were firing; want just at the current moment. Adding this as an option with the same funciton 