### PR TITLE
Node filtering refactoring to aggregate nodes by type and instance type

### DIFF
--- a/src/krkn_lib/models/telemetry/models.py
+++ b/src/krkn_lib/models/telemetry/models.py
@@ -11,11 +11,11 @@ class ScenarioTelemetry:
     Scenario Telemetry collection
     """
 
-    startTimeStamp: float
+    start_timestamp: float
     """
     Timestamp when the Krkn run started
     """
-    endTimeStamp: float
+    end_timestamp: float
     """
     Timestamp when the Krkn run ended
     """
@@ -23,11 +23,11 @@ class ScenarioTelemetry:
     """
     Scenario filename
     """
-    exitStatus: int
+    exit_status: int
     """
     Exit Status of the Scenario Run
     """
-    parametersBase64: str
+    parameters_base64: str
     """
         Scenario configuration file base64 encoded
     """
@@ -35,19 +35,19 @@ class ScenarioTelemetry:
 
     def __init__(self, json_object: any = None):
         if json_object is not None:
-            self.startTimeStamp = int(json_object.get("startTimeStamp"))
-            self.endTimeStamp = int(json_object.get("endTimeStamp"))
+            self.start_timestamp = int(json_object.get("start_timestamp"))
+            self.end_timestamp = int(json_object.get("end_timestamp"))
             self.scenario = json_object.get("scenario")
-            self.exitStatus = json_object.get("exitStatus")
-            self.parametersBase64 = json_object.get("parametersBase64")
+            self.exit_status = json_object.get("exit_status")
+            self.parameters_base64 = json_object.get("parameters_base64")
             self.parameters = json_object.get("parameters")
 
             if (
-                self.parametersBase64 is not None
-                and self.parametersBase64 != ""
+                self.parameters_base64 is not None
+                and self.parameters_base64 != ""
             ):
                 try:
-                    yaml_params = base64.b64decode(self.parametersBase64)
+                    yaml_params = base64.b64decode(self.parameters_base64)
                     yaml_object = yaml.safe_load(yaml_params)
                     json_string = json.dumps(yaml_object, indent=2)
                     self.parameters = json.loads(json_string)
@@ -55,7 +55,7 @@ class ScenarioTelemetry:
                         self.parameters, dict
                     ) and not isinstance(self.parameters, list):
                         raise Exception()
-                    self.parametersBase64 = ""
+                    self.parameters_base64 = ""
                 except Exception as e:
                     raise Exception(
                         "invalid parameters format: {0}".format(str(e))
@@ -63,11 +63,11 @@ class ScenarioTelemetry:
         else:
             # if constructor is called without params
             # property are initialized so are available
-            self.startTimeStamp = 0
-            self.endTimeStamp = 0
+            self.start_timestamp = 0
+            self.end_timestamp = 0
             self.scenario = ""
-            self.exitStatus = 0
-            self.parametersBase64 = ""
+            self.exit_status = 0
+            self.parameters_base64 = ""
             self.parameters = {}
 
 

--- a/src/krkn_lib/models/telemetry/models.py
+++ b/src/krkn_lib/models/telemetry/models.py
@@ -36,7 +36,7 @@ class ScenarioTelemetry:
     def __init__(self, json_object: any = None):
         if json_object is not None:
             self.startTimeStamp = int(json_object.get("startTimeStamp"))
-            self.endTimeStamp = json_object.get("endTimeStamp")
+            self.endTimeStamp = int(json_object.get("endTimeStamp"))
             self.scenario = json_object.get("scenario")
             self.exitStatus = json_object.get("exitStatus")
             self.parametersBase64 = json_object.get("parametersBase64")

--- a/src/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py
+++ b/src/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py
@@ -54,20 +54,11 @@ class KrknTelemetryKubernetes:
                 ]
             )
         )
-        node_infos = self.kubecli.get_nodes_infos()
-        worker_counter = 0
-        other_node_count = 0
+        node_infos, taints = self.kubecli.get_nodes_infos()
+        chaos_telemetry.node_summary_infos = node_infos
+        chaos_telemetry.node_taints = taints
         for info in node_infos:
-            if info.node_type != "worker":
-                other_node_count += 1
-                chaos_telemetry.node_summary_infos.append(info)
-            else:
-                if worker_counter == 0:
-                    chaos_telemetry.node_summary_infos.append(info)
-                worker_counter += 1
-
-        chaos_telemetry.total_node_count = other_node_count + worker_counter
-        chaos_telemetry.worker_count = worker_counter
+            chaos_telemetry.total_node_count += info.count
 
     def send_telemetry(
         self,

--- a/src/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py
+++ b/src/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py
@@ -512,7 +512,7 @@ class KrknTelemetryKubernetes:
             ).decode()
         except Exception as e:
             raise Exception("telemetry: {0}".format(str(e)))
-        scenario_telemetry.parametersBase64 = input_file_base64
+        scenario_telemetry.parameters_base64 = input_file_base64
 
     def put_cluster_events(
         self,

--- a/src/krkn_lib/tests/test_krkn_kubernetes.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes.py
@@ -739,8 +739,9 @@ class KrknKubernetesTests(BaseTest):
 
     def test_get_nodes_infos(self):
         telemetry = ChaosRunTelemetry()
-        nodes = self.lib_k8s.get_nodes_infos()
+        nodes, _ = self.lib_k8s.get_nodes_infos()
         for node in nodes:
+            self.assertTrue(node.count > 0)
             self.assertTrue(node.node_type)
             self.assertTrue(node.architecture)
             self.assertTrue(node.instance_type)

--- a/src/krkn_lib/tests/test_krkn_telemetry_kubernetes.py
+++ b/src/krkn_lib/tests/test_krkn_telemetry_kubernetes.py
@@ -28,7 +28,7 @@ class KrknTelemetryKubernetesTests(BaseTest):
         input_file_yaml_orig = yaml.safe_load(input_file_data_orig)
         input_file_yaml_processed = yaml.safe_load(
             base64.b64decode(
-                scenario_telemetry.parametersBase64.encode()
+                scenario_telemetry.parameters_base64.encode()
             ).decode()
         )
 

--- a/src/krkn_lib/tests/test_krkn_telemetry_models.py
+++ b/src/krkn_lib/tests/test_krkn_telemetry_models.py
@@ -8,43 +8,43 @@ class KrknTelemetryModelsTests(unittest.TestCase):
     def test_scenario_telemetry(self):
         test_valid_json = """
         {
-            "startTimeStamp": 1686141432,
-            "endTimeStamp": 1686141435,
+            "start_timestamp": 1686141432,
+            "end_timestamp": 1686141435,
             "scenario": "test",
-            "exitStatus": 0,
-            "parametersBase64": "cHJvcGVydHk6CiAgICB1bml0OiB1bml0CiAgICB0ZXN0OiB0ZXN0"
+            "exit_status": 0,
+            "parameters_base64": "cHJvcGVydHk6CiAgICB1bml0OiB1bml0CiAgICB0ZXN0OiB0ZXN0"
         }
         """  # NOQA
         # wrong base64 format
         test_invalid_json_wrong_base64 = """
         {
-            "startTimeStamp": 1686141432,
-            "endTimeStamp": 1686141435,
+            "start_timestamp": 1686141432,
+            "end_timestamp": 1686141435,
             "scenario": "test",
-            "exitStatus": 0,
-            "parametersBase64": "I'm a wrong base64"
+            "exit_status": 0,
+            "parameters_base64": "I'm a wrong base64"
         }
         """
 
         test_invalid_base64_bad_format = """
         {
-            "startTimeStamp": 1686141432,
-            "endTimeStamp": 1686141435,
+            "start_timestamp": 1686141432,
+            "end_timestamp": 1686141435,
             "scenario": "test",
-            "exitStatus": 0,
-            "parametersBase64": "SSdtIG5vdCBhIGdvb2Qgc3RyaW5nIDstXA=="
+            "exit_status": 0,
+            "parameters_base64": "SSdtIG5vdCBhIGdvb2Qgc3RyaW5nIDstXA=="
         }
 
         """
         json_obj = json.loads(test_valid_json)
 
         telemetry = ScenarioTelemetry(json_obj)
-        self.assertEqual(telemetry.startTimeStamp, 1686141432)
-        self.assertEqual(telemetry.endTimeStamp, 1686141435)
+        self.assertEqual(telemetry.start_timestamp, 1686141432)
+        self.assertEqual(telemetry.end_timestamp, 1686141435)
         self.assertEqual(telemetry.scenario, "test")
-        self.assertEqual(telemetry.exitStatus, 0)
+        self.assertEqual(telemetry.exit_status, 0)
         self.assertIsNotNone(telemetry.parameters)
-        self.assertEqual(telemetry.parametersBase64, "")
+        self.assertEqual(telemetry.parameters_base64, "")
         self.assertEqual(telemetry.parameters["property"]["unit"], "unit")
         self.assertEqual(telemetry.parameters["property"]["test"], "test")
         with self.assertRaises(Exception):
@@ -56,15 +56,17 @@ class KrknTelemetryModelsTests(unittest.TestCase):
             telemetry_empty_constructor = ScenarioTelemetry()
             self.assertIsNotNone(telemetry_empty_constructor)
             self.assertTrue(
-                hasattr(telemetry_empty_constructor, "startTimeStamp")
+                hasattr(telemetry_empty_constructor, "start_timestamp")
             )
             self.assertTrue(
-                hasattr(telemetry_empty_constructor, "endTimeStamp")
+                hasattr(telemetry_empty_constructor, "end_timestamp")
             )
             self.assertTrue(hasattr(telemetry_empty_constructor, "scenario"))
-            self.assertTrue(hasattr(telemetry_empty_constructor, "exitStatus"))
             self.assertTrue(
-                hasattr(telemetry_empty_constructor, "parametersBase64")
+                hasattr(telemetry_empty_constructor, "exit_status")
+            )
+            self.assertTrue(
+                hasattr(telemetry_empty_constructor, "parameters_base64")
             )
             self.assertTrue(hasattr(telemetry_empty_constructor, "parameters"))
         except Exception:
@@ -74,18 +76,18 @@ class KrknTelemetryModelsTests(unittest.TestCase):
         test_valid_json = """
         {
             "scenarios": [{
-                            "startTimeStamp": 1686141432,
-                            "endTimeStamp": 1686141435,
+                            "start_timestamp": 1686141432,
+                            "end_timestamp": 1686141435,
                             "scenario": "test",
-                            "exitStatus": 0,
-                            "parametersBase64": "cHJvcGVydHk6CiAgICB1bml0OiB1bml0CiAgICB0ZXN0OiB0ZXN0"
+                            "exit_status": 0,
+                            "parameters_base64": "cHJvcGVydHk6CiAgICB1bml0OiB1bml0CiAgICB0ZXN0OiB0ZXN0"
                         },
                         {
-                            "startTimeStamp": 1686141432,
-                            "endTimeStamp": 1686141435,
+                            "start_timestamp": 1686141432,
+                            "end_timestamp": 1686141435,
                             "scenario": "test",
-                            "exitStatus": 0,
-                            "parametersBase64": "cHJvcGVydHk6CiAgICB1bml0OiB1bml0CiAgICB0ZXN0OiB0ZXN0"
+                            "exit_status": 0,
+                            "parameters_base64": "cHJvcGVydHk6CiAgICB1bml0OiB1bml0CiAgICB0ZXN0OiB0ZXN0"
                         }],
             "node_summary_infos": [{
                     "name": "test_node"
@@ -103,11 +105,11 @@ class KrknTelemetryModelsTests(unittest.TestCase):
         test_invalid_json_scenarios_format = """
         {
             "scenarios":{
-                        "startTimeStamp": 1686141432,
-                        "endTimeStamp": 1686141435,
+                        "start_timestamp": 1686141432,
+                        "end_timestamp": 1686141435,
                         "scenario": "test",
-                        "exitStatus": 0,
-                        "parametersBase64": "cHJvcGVydHk6CiAgICB1bml0OiB1bml0CiAgICB0ZXN0OiB0ZXN0"
+                        "exit_status": 0,
+                        "parameters_base64": "cHJvcGVydHk6CiAgICB1bml0OiB1bml0CiAgICB0ZXN0OiB0ZXN0"
                         }
         }
         """  # NOQA
@@ -115,18 +117,18 @@ class KrknTelemetryModelsTests(unittest.TestCase):
         test_invalid_json_scenarios_element = """
         {
             "scenarios": [{
-                            "startTimeStamp": 1686141432,
-                            "endTimeStamp": 1686141435,
+                            "start_timestamp": 1686141432,
+                            "end_timestamp": 1686141435,
                             "scenario": "test",
-                            "exitStatus": 0,
-                            "parametersBase64": "cHJvcGVydHk6CiAgICB1bml0OiB1bml0CiAgICB0ZXN0OiB0ZXN0"
+                            "exit_status": 0,
+                            "parameters_base64": "cHJvcGVydHk6CiAgICB1bml0OiB1bml0CiAgICB0ZXN0OiB0ZXN0"
                         },
                         {
-                            "startTimeStamp": 1686141432,
-                            "endTimeStamp": 1686141435,
+                            "start_timestamp": 1686141432,
+                            "end_timestamp": 1686141435,
                             "scenario": "test",
-                            "exitStatus": 0,
-                            "parametersBase64": "SSdtIG5vdCBhIGdvb2Qgc3RyaW5nIDstXA=="
+                            "exit_status": 0,
+                            "parameters_base64": "SSdtIG5vdCBhIGdvb2Qgc3RyaW5nIDstXA=="
                         }
 
                        ]
@@ -139,7 +141,7 @@ class KrknTelemetryModelsTests(unittest.TestCase):
         self.assertEqual(len(telemetry.scenarios), 2)
         # tests that all scenarios have base64 parameter set to empty string
         for scenario in telemetry.scenarios:
-            self.assertEqual(scenario.parametersBase64, "")
+            self.assertEqual(scenario.parameters_base64, "")
 
         # test deserialization
         try:

--- a/src/krkn_lib/tests/test_krkn_telemetry_models.py
+++ b/src/krkn_lib/tests/test_krkn_telemetry_models.py
@@ -87,14 +87,16 @@ class KrknTelemetryModelsTests(unittest.TestCase):
                             "exitStatus": 0,
                             "parametersBase64": "cHJvcGVydHk6CiAgICB1bml0OiB1bml0CiAgICB0ZXN0OiB0ZXN0"
                         }],
-            "node_infos": [{
-                    "name": "test_node",
-                    "taints": [{
+            "node_summary_infos": [{
+                    "name": "test_node"
+                }],
+            "node_taints": [{
+                        "node_name": "test_node",
                         "key": "key",
                         "value": "value",
                         "effect": "NoSchedule"
-                    }]
-                }]
+            }]
+            
         }
         """  # NOQA
 


### PR DESCRIPTION
Tested both on krkn and on krkn-telemetry webservice, that's the telemetry.json new structure:
```json
{
    "scenarios": [
        {
            "startTimeStamp": 1709724304,
            "endTimeStamp": 1709724322.3046272,
            "scenario": "scenarios/arcaflow/cpu-hog/input.yaml",
            "exitStatus": 0,
            "parametersBase64": "",
            "parameters": {
                "input_list": [
                    {
                        "cpu_count": 1,
                        "cpu_load_percentage": 80,
                        "cpu_method": "all",
                        "duration": "1s",
                        "kubeconfig": "anonymized",
                        "namespace": "default",
                        "node_selector": {}
                    }
                ]
            }
        }
    ],
    "node_summary_infos": [
        {
            "count": 3,
            "architecture": "amd64",
            "instance_type": "m6i.xlarge",
            "node_type": "master",
            "kernel_version": "5.14.0-284.28.1.el9_2.x86_64",
            "kubelet_version": "v1.26.7+0ef5eae",
            "os_version": "Red Hat Enterprise Linux CoreOS 413.92.202308210212-0 (Plow)"
        },
        {
            "count": 3,
            "architecture": "amd64",
            "instance_type": "m6i.xlarge",
            "node_type": "worker",
            "kernel_version": "5.14.0-284.28.1.el9_2.x86_64",
            "kubelet_version": "v1.26.7+0ef5eae",
            "os_version": "Red Hat Enterprise Linux CoreOS 413.92.202308210212-0 (Plow)"
        }
    ],
    "node_taints": [
        {
            "node_name": "ip-10-0-140-210.us-west-2.compute.internal",
            "effect": "NoSchedule",
            "key": "node-role.kubernetes.io/master",
            "value": null
        },
        {
            "node_name": "ip-10-0-161-50.us-west-2.compute.internal",
            "effect": "NoSchedule",
            "key": "node-role.kubernetes.io/master",
            "value": null
        },
        {
            "node_name": "ip-10-0-168-232.us-west-2.compute.internal",
            "effect": "NoExecute",
            "key": "key1",
            "value": "value1"
        },
        {
            "node_name": "ip-10-0-221-103.us-west-2.compute.internal",
            "effect": "NoExecute",
            "key": "key1",
            "value": "value1"
        },
        {
            "node_name": "ip-10-0-221-103.us-west-2.compute.internal",
            "effect": "NoSchedule",
            "key": "node-role.kubernetes.io/master",
            "value": null
        }
    ],
    "kubernetes_objects_count": {
        "ConfigMap": 515,
        "Pod": 237,
        "Secret": 935,
        "Deployment": 63,
        "Route": 8,
        "Build": 1
    },
    "network_plugins": [
        "OVNKubernetes"
    ],
    "total_node_count": 6,
    "cloud_infrastructure": "AWS",
    "run_uuid": "d92db8e5-e605-46ad-ac11-f10a8160ae12"
}
```