### PR TITLE
splitted recovery time  + removed urrlib3 warnings

### DIFF
--- a/src/krkn_lib/models/k8s/models.py
+++ b/src/krkn_lib/models/k8s/models.py
@@ -205,17 +205,33 @@ class AffectedPod:
     """
     Namespace of the pod
     """
-    recovery_time: float
+    pod_rescheduling_time: float
     """
-    Time needed to return in "Ready" state
+    The time that the cluster took to reschedule
+    the pod after the kill scenario
+    """
+    pod_readiness_time: float
+    """
+    The time the pod took to become ready after being scheduled
+    """
+    total_recovery_time: float
+    """
+    Total amount of time the pod took to become ready
     """
 
     def __init__(
-        self, pod_name: str, namespace: str, recovery_time: float = None
+        self,
+        pod_name: str,
+        namespace: str,
+        total_recovery_time: float = None,
+        pod_readiness_time: float = None,
+        pod_rescheduling_time: float = None,
     ):
         self.pod_name = pod_name
         self.namespace = namespace
-        self.recovery_time = recovery_time
+        self.total_recovery_time = total_recovery_time
+        self.pod_readiness_time = pod_readiness_time
+        self.pod_rescheduling_time = pod_rescheduling_time
 
 
 class PodsStatus:
@@ -242,7 +258,9 @@ class PodsStatus:
                     AffectedPod(
                         recovered["pod_name"],
                         recovered["namespace"],
-                        float(recovered["recovery_time"]),
+                        float(recovered["total_recovery_time"]),
+                        float(recovered["pod_readiness_time"]),
+                        float(recovered["pod_rescheduling_time"]),
                     )
                 )
             for unrecovered in json_object["unrecovered"]:

--- a/src/krkn_lib/prometheus/krkn_prometheus.py
+++ b/src/krkn_lib/prometheus/krkn_prometheus.py
@@ -1,4 +1,6 @@
 import logging
+import warnings
+
 import math
 import re
 import sys
@@ -7,6 +9,7 @@ from datetime import datetime, timedelta
 from io import StringIO
 from typing import Optional
 
+import urllib3
 from prometheus_api_client import PrometheusConnect
 
 
@@ -25,6 +28,12 @@ class KrknPrometheus:
         :param prometheus_bearer_token: the bearer token to authenticate
             the query (optional).
         """
+
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        urllib3.disable_warnings(DeprecationWarning)
+        warnings.filterwarnings(
+            action="ignore", message="unclosed", category=ResourceWarning
+        )
         headers = {}
         if prometheus_bearer_token is not None:
             bearer = "Bearer " + prometheus_bearer_token

--- a/src/krkn_lib/telemetry/elastic.py
+++ b/src/krkn_lib/telemetry/elastic.py
@@ -1,4 +1,7 @@
 import time
+
+import urllib3
+
 from krkn_lib.utils.safe_logger import SafeLogger
 from elasticsearch import Elasticsearch
 
@@ -7,6 +10,8 @@ class KrknElastic:
     es = None
 
     def __init__(self, safe_logger: SafeLogger, elastic_url: str):
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        urllib3.disable_warnings(DeprecationWarning)
         self.safe_logger = safe_logger
         try:
             # create Elasticsearch object

--- a/src/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py
+++ b/src/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py
@@ -2,6 +2,9 @@ import base64
 import tempfile
 import threading
 import time
+import warnings
+
+import urllib3
 import yaml
 import requests
 import os
@@ -24,6 +27,11 @@ class KrknTelemetryKubernetes:
     def __init__(
         self, safe_logger: SafeLogger, lib_kubernetes: KrknKubernetes
     ):
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        urllib3.disable_warnings(DeprecationWarning)
+        warnings.filterwarnings(
+            action="ignore", message="unclosed", category=ResourceWarning
+        )
         self.kubecli = lib_kubernetes
         self.safe_logger = safe_logger
 

--- a/src/krkn_lib/tests/test_krkn_kubernetes.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes.py
@@ -959,7 +959,9 @@ class KrknKubernetesTests(BaseTest):
         self.assertEqual(len(result.recovered), 1)
         self.assertEqual(result.recovered[0].pod_name, delayed_respawn)
         self.assertEqual(result.recovered[0].namespace, namespace)
-        self.assertTrue(result.recovered[0].recovery_time >= pod_delay)
+        self.assertTrue(result.recovered[0].pod_readiness_time > 0)
+        self.assertTrue(result.recovered[0].pod_rescheduling_time > 0)
+        self.assertTrue(result.recovered[0].total_recovery_time >= pod_delay)
         self.assertEqual(len(result.unrecovered), 0)
 
     def test_pods_by_namespace_pattern_and_label_same_name_respawn(
@@ -1001,7 +1003,9 @@ class KrknKubernetesTests(BaseTest):
         self.assertEqual(len(result.recovered), 1)
         self.assertEqual(result.recovered[0].pod_name, delayed_1)
         self.assertEqual(result.recovered[0].namespace, namespace)
-        self.assertTrue(result.recovered[0].recovery_time >= pod_delay)
+        self.assertTrue(result.recovered[0].pod_readiness_time > 0)
+        self.assertTrue(result.recovered[0].pod_rescheduling_time > 0)
+        self.assertTrue(result.recovered[0].total_recovery_time >= pod_delay)
         self.assertEqual(len(result.unrecovered), 0)
 
     def test_pods_by_label_respawn_timeout(self):

--- a/src/krkn_lib/tests/test_krkn_telemetry_models.py
+++ b/src/krkn_lib/tests/test_krkn_telemetry_models.py
@@ -18,7 +18,9 @@ class KrknTelemetryModelsTests(unittest.TestCase):
                     {
                         "pod_name":"test-pod",
                         "namespace":"test-namespace",
-                        "recovery_time":3.14
+                        "pod_rescheduling_time":9.8,
+                        "pod_readiness_time":2.71,
+                        "total_recovery_time":3.14
                     }
                 ],
                 "unrecovered":[
@@ -68,11 +70,15 @@ class KrknTelemetryModelsTests(unittest.TestCase):
         for recovered in telemetry.affected_pods.recovered:
             self.assertIsNotNone(recovered.pod_name)
             self.assertIsNotNone(recovered.namespace)
-            self.assertIsNotNone(recovered.recovery_time)
+            self.assertIsNotNone(recovered.pod_readiness_time)
+            self.assertIsNotNone(recovered.pod_rescheduling_time)
+            self.assertIsNotNone(recovered.total_recovery_time)
         for unrecovered in telemetry.affected_pods.unrecovered:
             self.assertIsNotNone(unrecovered.pod_name)
             self.assertIsNotNone(unrecovered.namespace)
-            self.assertIsNone(unrecovered.recovery_time)
+            self.assertIsNone(unrecovered.pod_readiness_time)
+            self.assertIsNone(unrecovered.pod_rescheduling_time)
+            self.assertIsNone(unrecovered.total_recovery_time)
         self.assertIsNotNone(telemetry.parameters)
         self.assertEqual(telemetry.parameters_base64, "")
         self.assertEqual(telemetry.parameters["property"]["unit"], "unit")


### PR DESCRIPTION
recovery time is now splitted in :

- `pod_readiness_time`
- `pod_rescheduling_time`
- `total_recovery_time`

Bonus: removed annoying urllib3 warnings that pollute the pipeline and the krkn output