### PR TITLE
Node type

### DIFF
--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -2084,19 +2084,19 @@ class KrknKubernetes:
                     node_info.instance_type = "unknown"
 
                 if node_type_infra_label in node.metadata.labels.keys():
-                    node_info.node_type = "infra"
+                    node_info.nodes_type= "infra"
                 elif node_type_worker_label in node.metadata.labels.keys():
-                    node_info.node_type = "worker"
+                    node_info.nodes_type= "worker"
                 elif node_type_master_label in node.metadata.labels.keys():
-                    node_info.node_type = "master"
+                    node_info.nodes_type= "master"
                 elif node_type_workload_label in node.metadata.labels.keys():
-                    node_info.node_type = "workload"
+                    node_info.nodes_type= "workload"
                 elif (
                     node_type_application_label in node.metadata.labels.keys()
                 ):
-                    node_info.node_type = "application"
+                    node_info.nodes_type= "application"
                 else:
-                    node_info.node_type = "unknown"
+                    node_info.nodes_type= "unknown"
 
                 node_info.architecture = node.status.node_info.architecture
                 node_info.architecture = node.status.node_info.architecture

--- a/src/krkn_lib/models/telemetry/models.py
+++ b/src/krkn_lib/models/telemetry/models.py
@@ -138,7 +138,7 @@ class NodeInfo:
     """
     Cloud instance type (if available)
     """
-    node_type: str = ""
+    nodes_type: str = ""
     """
     Node Type (worker/infra/master etc.)
     """
@@ -162,8 +162,8 @@ class NodeInfo:
                 if "instance_type" in json_dict
                 else None
             )
-            self.node_type = (
-                json_dict["node_type"] if "node_type" in json_dict else None
+            self.nodes_type = (
+                json_dict["nodes_type"] if "nodes_type" in json_dict else None
             )
             self.kernel_version = (
                 json_dict["kernel_version"]
@@ -184,7 +184,7 @@ class NodeInfo:
             return (
                 other.architecture == self.architecture
                 and other.instance_type == self.instance_type
-                and other.node_type == self.node_type
+                and other.nodes_type == self.nodes_type
                 and other.kernel_version == self.kernel_version
                 and other.kubelet_version == self.kubelet_version
                 and other.os_version == self.os_version
@@ -195,7 +195,7 @@ class NodeInfo:
     def __repr__(self):
         return (
             f"{self.architecture} {self.instance_type} "
-            f"{self.node_type} {self.kernel_version} "
+            f"{self.nodes_type} {self.kernel_version} "
             f"{self.kubelet_version} {self.os_version}"
         )
 

--- a/src/krkn_lib/tests/test_krkn_kubernetes.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes.py
@@ -763,7 +763,7 @@ class KrknKubernetesTests(BaseTest):
         nodes, _ = self.lib_k8s.get_nodes_infos()
         for node in nodes:
             self.assertTrue(node.count > 0)
-            self.assertTrue(node.node_type)
+            self.assertTrue(node.nodes_type)
             self.assertTrue(node.architecture)
             self.assertTrue(node.instance_type)
             self.assertTrue(node.os_version)


### PR DESCRIPTION
Node type was not a valid key for elastic search, updating it to "nodes_type" I was able to see it correctly.

BEFORE: 
![esnodetype](https://github.com/user-attachments/assets/76fca231-1bc4-4fe3-8062-db59b68057b2)


AFTER: 
![newnodestype](https://github.com/user-attachments/assets/32918141-35a2-4b42-99b9-facc5a98421d)
