### PR TITLE
Taking out resource version

### DIFF
--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -1713,7 +1713,7 @@ class KrknKubernetes:
         return node_name
 
     def watch_node_status(
-        self, node: str, status: str, timeout: int, resource_version: str
+        self, node: str, status: str, timeout: int
     ):
         """
         Watch for a specific node status
@@ -1728,7 +1728,6 @@ class KrknKubernetes:
             self.cli.list_node,
             field_selector=f"metadata.name={node}",
             timeout_seconds=timeout,
-            resource_version=f"{resource_version}",
         ):
             conditions = [
                 status


### PR DESCRIPTION
I have been noticing in the node scenarios that when waiting for an "Unknown" status of the node after a node has been stopped it is waiting a very long time and then continues. I think this might be because of an issue with the wait_node_status has an improper/extra parameter. After taking the resource_version out I was properly able to run the scenario with no extra waits

Hitting the timeout even though node was already in unknown state output (timeout was 360 seconds) 
```
2024-11-04 14:33:40,587 [INFO] Status of vm STOPPING
2024-11-04 14:33:45,740 [INFO] Status of vm STOPPING
2024-11-04 14:33:50,915 [INFO] Status of vm STOPPING
2024-11-04 14:33:56,058 [INFO] Status of vm TERMINATED
2024-11-04 14:33:56,058 [INFO] Node with instance ID: prubenda418-1-5hhsr-master-1 is in stopped state


2024-11-04 14:39:56,177 [INFO] Waiting for 10 seconds before starting the node
2024-11-04 14:40:06,180 [INFO] Starting node_start_scenario injection
2024-11-04 14:40:11,090 [INFO] Starting the node prubenda418-1-5hhsr-master-1 with instance ID: prubenda418-1-5hhsr-master-1 
2024-11-04 14:40:11,559 [INFO] vm name prubenda418-1-5hhsr-master-1 started
2024-11-04 14:40:11,699 [INFO] Status of vm TERMINATED
2024-11-04 14:40:16,847 [INFO] Status of vm STAGING
2024-11-04 14:40:21,985 [INFO] Status of vm RUNNING
2024-11-04 14:41:10,991 [INFO] Status of node prubenda418-1-5hhsr-master-1: Unknown
2024-11-04 14:41:17,845 [INFO] Node with instance ID: prubenda418-1-5hhsr-master-1 is in running state
2024-11-04 14:41:17,848 [INFO] node_start_scenario has been successfully injected!
```


After taking out resource version, not waiting till timeout and still properly getting updated status one node becomes ready 

```
2024-11-04 14:46:29,231 [INFO] Status of vm STOPPING
2024-11-04 14:46:34,407 [INFO] Status of vm STOPPING
2024-11-04 14:46:39,545 [INFO] Status of vm STOPPING
2024-11-04 14:46:44,703 [INFO] Status of vm STOPPING
2024-11-04 14:46:49,865 [INFO] Status of vm STOPPING
2024-11-04 14:46:55,040 [INFO] Status of vm STOPPING
2024-11-04 14:47:00,227 [INFO] Status of vm STOPPING
2024-11-04 14:47:05,373 [INFO] Status of vm TERMINATED
2024-11-04 14:47:05,374 [INFO] Node with instance ID: prubenda418-1-5hhsr-worker-b-qpnzn is in stopped state
2024-11-04 14:47:05,553 [INFO] Waiting for 10 seconds before starting the node
2024-11-04 14:47:15,556 [INFO] Starting node_start_scenario injection
2024-11-04 14:47:17,184 [INFO] Starting the node prubenda418-1-5hhsr-worker-b-qpnzn with instance ID: prubenda418-1-5hhsr-worker-b-qpnzn 
2024-11-04 14:47:17,687 [INFO] vm name prubenda418-1-5hhsr-worker-b-qpnzn started
2024-11-04 14:47:17,839 [INFO] Status of vm TERMINATED
2024-11-04 14:47:23,003 [INFO] Status of vm STAGING
2024-11-04 14:47:28,159 [INFO] Status of vm RUNNING
Status of node %s: %s prubenda418-1-5hhsr-worker-b-qpnzn Unknown
Status of node %s: %s prubenda418-1-5hhsr-worker-b-qpnzn False
Status of node %s: %s prubenda418-1-5hhsr-worker-b-qpnzn False
Status of node %s: %s prubenda418-1-5hhsr-worker-b-qpnzn False
Status of node %s: %s prubenda418-1-5hhsr-worker-b-qpnzn False
Status of node %s: %s prubenda418-1-5hhsr-worker-b-qpnzn False
2024-11-04 14:48:10,681 [INFO] Node with instance ID: prubenda418-1-5hhsr-worker-b-qpnzn is in running state
2024-11-04 14:48:10,681 [INFO] node_start_scenario has been successfully injected!
```