### PR TITLE
Adding node id to affected node info

### DIFF
--- a/src/krkn_lib/models/elastic/models.py
+++ b/src/krkn_lib/models/elastic/models.py
@@ -87,6 +87,7 @@ class ElasticPodsStatus(InnerDoc):
 
 class ElasticAffectedNodes(InnerDoc):
     node_name = Text(fields={"keyword": Keyword()})
+    node_id = Text()
     not_ready_time = Float()
     ready_time = Float()
     stopped_time = Float()
@@ -178,6 +179,7 @@ class ElasticChaosRunTelemetry(Document):
                 affected_nodes=[
                     ElasticAffectedNodes(
                         node_name=node.node_name,
+                        node_id=node.node_id,
                         not_ready_time=node.not_ready_time,
                         ready_time=node.ready_time,
                         stopped_time=node.stopped_time,

--- a/src/krkn_lib/models/k8s/models.py
+++ b/src/krkn_lib/models/k8s/models.py
@@ -244,6 +244,10 @@ class AffectedNode:
     """
     Name of the node
     """
+    node_id: str
+    """
+    Id of the node
+    """
     ready_time: float
     """
     Amount of time the node took to get to a ready state
@@ -265,6 +269,7 @@ class AffectedNode:
     def __init__(
         self,
         node_name: str = "",
+        node_id: str = "",
         not_ready_time: float = 0,
         ready_time: float = 0,
         stopped_time: float = 0,
@@ -273,6 +278,7 @@ class AffectedNode:
         json_object: str = None,
     ):
         self.node_name = node_name
+        self.node_id = node_id
         self.not_ready_time = float(not_ready_time)
         self.ready_time = float(ready_time)
         self.stopped_time = float(stopped_time)
@@ -280,8 +286,8 @@ class AffectedNode:
         self.terminating_time = float(terminating_time)
 
         if json_object:
-            print("json object" + str(json_object))
             self.node_name = json_object["node_name"]
+            self.node_id = json_object["node_id"]
             self.set_not_ready_time(json_object["not_ready_time"])
             self.set_ready_time(json_object["ready_time"])
             self.set_cloud_stopping_time(json_object["stopped_time"])
@@ -289,7 +295,6 @@ class AffectedNode:
             self.set_terminating_time(json_object["terminating_time"])
 
     def set_affected_node_status(self, status: str, total_time: float):
-        print("affected node status" + str(status))
         if status == "Unknown":
             self.set_not_ready_time(total_time)
         elif status == "True":
@@ -355,11 +360,11 @@ class AffectedNodeStatus:
         for item in reversed(match_found):
             self.affected_nodes.pop(item)
 
-    def get_affected_node_index(self, node_name):
+    def get_affected_node_index(self, node_id):
         counter = 0
 
         for affected_node in self.affected_nodes:
-            if affected_node.node_name == node_name:
+            if affected_node.node_id == node_id:
                 return self.affected_nodes[counter]
             counter += 1
 

--- a/src/krkn_lib/tests/base_test.py
+++ b/src/krkn_lib/tests/base_test.py
@@ -523,6 +523,7 @@ class BaseTest(unittest.TestCase):
                     "affected_nodes": [
                         {
                             "node_name": "kind-control-plane",
+                            "node_id": "test",
                             "ready_time": 2.71,
                             "not_ready_time": 3.14,
                             "stopped_time": 0,

--- a/src/krkn_lib/tests/test_krkn_elastic_models.py
+++ b/src/krkn_lib/tests/test_krkn_elastic_models.py
@@ -105,6 +105,13 @@ class TestKrknElasticModels(BaseTest):
 
         self.assertEqual(
             elastic_telemetry.scenarios[0]
+            .affected_nodes[0]
+            .node_id,
+            "test",
+        )
+
+        self.assertEqual(
+            elastic_telemetry.scenarios[0]
             .affected_nodes[0].ready_time,
             2.71,
         )

--- a/src/krkn_lib/tests/test_krkn_telemetry_models.py
+++ b/src/krkn_lib/tests/test_krkn_telemetry_models.py
@@ -62,6 +62,7 @@ class KrknTelemetryModelsTests(unittest.TestCase):
             "affected_nodes":[
                 {
                     "node_name":"kind-control-plane",
+                    "node_id":"test",
                     "ready_time":2.71,
                     "not_ready_time":3.14,
                     "stopped_time":0.0,
@@ -114,6 +115,18 @@ class KrknTelemetryModelsTests(unittest.TestCase):
             self.assertIsNone(unrecovered.pod_readiness_time)
             self.assertIsNone(unrecovered.pod_rescheduling_time)
             self.assertIsNone(unrecovered.total_recovery_time)
+
+        self.assertEqual(len(telemetry.affected_nodes), 1)
+
+        self.assertEqual((telemetry.affected_nodes[0].node_id), "test")
+        self.assertEqual((telemetry.affected_nodes[0].node_name), "kind-control-plane")
+
+        self.assertEqual((telemetry.affected_nodes[0].not_ready_time), 3.14)
+        self.assertEqual((telemetry.affected_nodes[0].ready_time), 2.71)
+        self.assertEqual((telemetry.affected_nodes[0].running_time), 0)
+        self.assertEqual((telemetry.affected_nodes[0].stopped_time), 0)
+        self.assertEqual((telemetry.affected_nodes[0].terminating_time), 0)
+            
         self.assertIsNotNone(telemetry.parameters)
         self.assertEqual(telemetry.parameters_base64, "")
         self.assertEqual(telemetry.parameters["property"]["unit"], "unit")


### PR DESCRIPTION
For the cluster shut down scenario, we do not easily have the node name to find the affected node properly. Adding the node instance id will help easily be able to get the details of the affected node