### PR TITLE
815_krknPR_about_disk_failure_simulation 

### DIFF
--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -3363,3 +3363,84 @@ class KrknKubernetes:
         resources.memory = json_obj["node"]["memory"]["availableBytes"]
         resources.disk_space = json_obj["node"]["fs"]["availableBytes"]
         return resources
+
+    def simulate_disk_failure(self, node_name: str, disk_path: str, timeout: int = 300) -> bool:
+        """
+        Simulates a disk failure on a specific node by offlining the disk.
+        This is done by creating a privileged pod on the target node and using
+        sysfs to offline the disk.
+
+        :param node_name: The name of the node where the disk failure should be simulated
+        :param disk_path: The path of the disk to be failed (e.g., /dev/sdb)
+        :param timeout: Timeout in seconds for the operation (default 300)
+        :return: True if the operation was successful, False otherwise
+        """
+        try:
+            # Validate disk path
+            if not disk_path or not disk_path.startswith('/dev/'):
+                raise ValueError("Invalid disk path. Must start with /dev/")
+
+            # Create a unique pod name
+            pod_name = f"disk-failure-{get_random_string(5)}"
+            namespace = "default"
+
+            # Create a privileged pod on the target node
+            file_loader = PackageLoader("krkn_lib.k8s", "templates")
+            env = Environment(loader=file_loader, autoescape=True)
+            pod_template = env.get_template("node_exec_pod.j2")
+            pod_body = yaml.safe_load(
+                pod_template.render(nodename=node_name, podname=pod_name)
+            )
+
+            # Add host path volume for sysfs
+            pod_body["spec"]["volumes"].append({
+                "name": "sysfs",
+                "hostPath": {
+                    "path": "/sys",
+                    "type": "Directory"
+                }
+            })
+
+            # Add volume mount to container
+            pod_body["spec"]["containers"][0]["volumeMounts"].append({
+                "name": "sysfs",
+                "mountPath": "/sys",
+                "readOnly": True
+            })
+
+            # Create the pod
+            self.create_pod(pod_body, namespace, timeout)
+
+            # Wait for pod to be running
+            while not self.is_pod_running(pod_name, namespace):
+                time.sleep(5)
+                continue
+
+            # Get the disk name from the path
+            disk_name = disk_path.split('/')[-1]
+
+            # Offline the disk using sysfs
+            offline_command = [
+                "sh", "-c",
+                f"echo 1 > /sys/block/{disk_name}/device/delete"
+            ]
+
+            try:
+                self.exec_cmd_in_pod(
+                    offline_command,
+                    pod_name,
+                    namespace,
+                    None
+                )
+                logging.info(f"Successfully simulated disk failure on {disk_path} for node {node_name}")
+                return True
+            except Exception as e:
+                logging.error(f"Failed to simulate disk failure: {str(e)}")
+                return False
+            finally:
+                # Clean up the pod
+                self.delete_pod(pod_name, namespace)
+
+        except Exception as e:
+            logging.error(f"Error in simulate_disk_failure: {str(e)}")
+            return False


### PR DESCRIPTION
## Description
This PR adds disk failure simulation functionality to krkn-lib, which will be used by the main krkn repository for disk failure chaos scenarios. The implementation uses Kubernetes-native approaches instead of direct `oc debug` commands.

## Context
This PR addresses the following comment from the main krkn repository: [PR](https://github.com/krkn-chaos/krkn/pull/815)
> "We try to keep krkn as Kubernetes-based as possible. Can you try using this function in krkn-lib instead of oc debug to be sure this functionality can work on all cluster types?" 

The original implementation used OpenShift-specific `oc debug` commands, which limited the functionality to OpenShift clusters only. This PR moves the functionality to krkn-lib and implements it using pure Kubernetes-native approaches.

## Why a new PR in krkn-lib?
1. **Architectural Decision**: krkn-lib is designed to contain shared functionality that works across different Kubernetes distributions. Moving the disk failure simulation here follows this architectural pattern.

2. **Distribution Agnostic**: The current implementation in krkn uses OpenShift-specific commands (`oc debug`). Moving this to krkn-lib and using Kubernetes-native approaches makes it work across all Kubernetes distributions.

3. **Code Reusability**: This functionality can be reused by other components or projects that use krkn-lib.

## Changes
- Added `simulate_disk_failure` method to `KrknKubernetes` class
- Replaced OpenShift-specific `oc debug` commands with Kubernetes-native approaches:
  - Uses privileged pods for node operations
  - Uses sysfs for disk operations
  - Uses standard Kubernetes volume mounts
- Includes proper validation and error handling
- Follows Kubernetes best practices for pod management
- Maintains security with read-only mounts and proper cleanup

## Related Issues and PR
[PR 815](https://github.com/krkn-chaos/krkn/pull/815)
Issues [1](https://github.com/krkn-chaos/krkn/issues/664) & [2](https://github.com/krkn-chaos/krkn-hub/issues/192)