### PR TITLE
Adding field selectors to listing pods

### DIFF
--- a/src/krkn_lib/k8s/pods_monitor_pool.py
+++ b/src/krkn_lib/k8s/pods_monitor_pool.py
@@ -26,7 +26,7 @@ class PodsMonitorPool:
         self.events: list[Event] = []
 
     def select_and_monitor_by_label(
-        self, label_selector: str, max_timeout: int
+        self, label_selector: str, field_selector: str, max_timeout: int
     ):
         """
         Pushes into the pool a monitoring thread for all the pods identified
@@ -47,18 +47,21 @@ class PodsMonitorPool:
         event = Event()
         self.events.append(event)
         pods_and_namespaces = self.krkn_lib.select_pods_by_label(
-            label_selector=label_selector
+            label_selector=label_selector,
+            field_selector=field_selector
         )
         pod_monitor_thread = self.krkn_lib.monitor_pods_by_label(
             label_selector=label_selector,
             pods_and_namespaces=pods_and_namespaces,
+            field_selector=field_selector,
             max_timeout=max_timeout,
             event=event,
         )
         self.pods_monitor_threads.append(pod_monitor_thread)
 
     def select_and_monitor_by_name_pattern_and_namespace_pattern(
-        self, pod_name_pattern: str, namespace_pattern: str, max_timeout: int
+        self, pod_name_pattern: str, namespace_pattern: str, field_selector: str,
+        max_timeout: int
     ):
         """
         Pushes into the pool a monitoring thread for all the pods identified
@@ -90,6 +93,7 @@ class PodsMonitorPool:
             self.krkn_lib.select_pods_by_name_pattern_and_namespace_pattern(
                 pod_name_pattern=pod_name_pattern,
                 namespace_pattern=namespace_pattern,
+                field_selector=field_selector
             )
         )
 
@@ -98,6 +102,7 @@ class PodsMonitorPool:
                 pod_name_pattern=pod_name_pattern,
                 namespace_pattern=namespace_pattern,
                 pods_and_namespaces=pods_and_namespaces,
+                field_selector=field_selector,
                 max_timeout=max_timeout,
                 event=event,
             )
@@ -109,6 +114,7 @@ class PodsMonitorPool:
         self,
         namespace_pattern: str,
         label_selector: str,
+        field_selector: str = None,
         max_timeout=30,
     ):
         """
@@ -138,6 +144,7 @@ class PodsMonitorPool:
             self.krkn_lib.select_pods_by_namespace_pattern_and_label(
                 namespace_pattern=namespace_pattern,
                 label_selector=label_selector,
+                field_selector=field_selector
             )
         )
 
@@ -146,6 +153,7 @@ class PodsMonitorPool:
                 namespace_pattern=namespace_pattern,
                 label_selector=label_selector,
                 pods_and_namespaces=pods_and_namespaces,
+                field_selector=field_selector,
                 max_timeout=max_timeout,
                 event=event,
             )

--- a/src/krkn_lib/models/elastic/models.py
+++ b/src/krkn_lib/models/elastic/models.py
@@ -10,7 +10,6 @@ from elasticsearch_dsl import (
     Keyword,
     Nested,
     Text,
-    Boolean
 )
 
 from krkn_lib.models.telemetry import ChaosRunTelemetry
@@ -106,13 +105,15 @@ class ElasticTaint(InnerDoc):
     value = Text()
     effect = Text()
 
+
 class ElasticHealthChecks(InnerDoc):
     url = Text()
-    status= Boolean()
-    status_code= Text()
-    start_timestamp= Date()
-    end_timestamp= Date()
-    duration= Float()
+    status = Boolean()
+    status_code = Text()
+    start_timestamp = Date()
+    end_timestamp = Date()
+    duration = Float()
+
 
 class ElasticChaosRunTelemetry(Document):
     scenarios = Nested(ElasticScenarioTelemetry, multi=True)
@@ -210,9 +211,13 @@ class ElasticChaosRunTelemetry(Document):
                     url=info.url,
                     status=info.status,
                     status_code=info.status_code,
-                    start_timestamp=datetime.datetime.fromisoformat(str(info.start_timestamp)),
-                    end_timestamp=datetime.datetime.fromisoformat(str(info.end_timestamp)),
-                    duration=info.duration
+                    start_timestamp=datetime.datetime.fromisoformat(
+                        str(info.start_timestamp)
+                    ),
+                    end_timestamp=datetime.datetime.fromisoformat(
+                        str(info.end_timestamp)
+                    ),
+                    duration=info.duration,
                 )
                 for info in chaos_run_telemetry.health_checks
             ]

--- a/src/krkn_lib/tests/base_test.py
+++ b/src/krkn_lib/tests/base_test.py
@@ -490,6 +490,13 @@ class BaseTest(unittest.TestCase):
         )
         thread.daemon = True
         thread.start()
+    
+    def background_delete_ns(self, namespace: str):
+        thread = threading.Thread(
+            target=self.lib_k8s.delete_namespace, args=(namespace,)
+        )
+        thread.daemon = True
+        thread.start()
 
     def get_ChaosRunTelemetry_json(self, run_uuid: str) -> dict:
         example_data = {

--- a/src/krkn_lib/tests/test_krkn_kubernetes_get.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_get.py
@@ -54,8 +54,18 @@ class KrknKubernetesTestsGet(BaseTest):
         # test with label_selector filter
         results = self.lib_k8s.get_all_pods("random=%s" % random_label)
         self.assertTrue(len(results) == 1)
-        self.assertEqual(results[0][0], "kraken-deployment")
         self.assertEqual(results[0][1], namespace)
+        self.assertEqual(results[0][0], "kraken-deployment")
+        self.wait_pod("kraken-deployment",namespace)
+        results = self.lib_k8s.get_all_pods("random=%s" % random_label, field_selector="status.phase=Running")
+        print('resuls' + str(results))
+        self.assertTrue(len(results) == 1)
+        self.assertEqual(results[0][1], namespace)
+        self.assertEqual(results[0][0], "kraken-deployment")
+
+        results = self.lib_k8s.get_all_pods(field_selector="status.phase=Running")
+        self.assertTrue(len(results) >= 1)
+        
         self.pod_delete_queue.put(["kraken-deployment", namespace])
 
     def test_get_pod_log(self):
@@ -134,6 +144,9 @@ class KrknKubernetesTestsGet(BaseTest):
             self.assertIsNotNone(info.podIP)
             self.assertIsNotNone(info.nodeName)
             self.assertIsNotNone(info.containers)
+
+            info = self.lib_k8s.get_pod_info("test1", namespace)
+            self.assertIsNone(info)
         except Exception as e:
             logging.error("test raised exception {0}".format(str(e)))
             self.assertTrue(False)

--- a/src/krkn_lib/tests/test_krkn_kubernetes_list.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_list.py
@@ -70,6 +70,15 @@ class KrknKubernetesTestsList(BaseTest):
         pods = self.lib_k8s.list_pods(namespace=namespace)
         self.assertTrue(len(pods) == 1)
         self.assertIn("kraken-deployment", pods)
+
+        self.wait_pod(pods[0],namespace)
+
+        pods = self.lib_k8s.list_pods(namespace=namespace, field_selector="status.phase=Running")
+        self.assertTrue(len(pods) == 1)
+        self.assertIn("kraken-deployment", pods)
+
+        pods = self.lib_k8s.list_pods(namespace=namespace, field_selector="status.phase=Terminating")
+        self.assertTrue(len(pods) == 0)
         self.pod_delete_queue.put(["kraken-deployment", namespace])
 
     def test_list_ready_nodes(self):


### PR DESCRIPTION
## Description  
In many cases we will want to only find running pods, we can use a built in kubernetes field on listing pod calls to help with us not having to do our own queries 

Adding tests now 

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  