### PR TITLE
Add host volume to node execution pod template

### DIFF
--- a/src/krkn_lib/k8s/templates/node_exec_pod.j2
+++ b/src/krkn_lib/k8s/templates/node_exec_pod.j2
@@ -19,7 +19,12 @@ spec:
     - mountPath: /run/dbus/system_bus_socket
       name: dbus
       readOnly: true
+    - name: host
+      mountPath: /host      
   volumes:
   - name: dbus
     hostPath:
       path: /run/dbus/system_bus_socket
+  - name: host
+    hostPath:
+      path: /      


### PR DESCRIPTION
This update introduces a new volume named 'host' that mounts the host filesystem at the path '/host' in the node execution pod template. This change enhances the pod's access to the host environment.

Depends on: krkn-chaos/krkn#855

