### PR TITLE
add default /tmp dir to test_krkn_kubernetes_exec.py

### DIFF
--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -2384,9 +2384,7 @@ class KrknKubernetes:
             # due to pipes and scripts the command is executed in
 
             if not os.path.isdir(download_path):
-                raise Exception(
-                    f"download path {download_path} does not exist"
-                )
+                os.mkdir(download_path)
             if not self.path_exists_in_pod(
                 pod_name, container_name, namespace, remote_archive_path
             ):

--- a/src/krkn_lib/tests/test_krkn_kubernetes_exec.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_exec.py
@@ -124,7 +124,7 @@ class KrknKubernetesTestsExec(BaseTest):
             self.fail(f"exception on node command execution: {e}")
 
     def test_download_folder_from_pod_as_archive(self):
-        workdir_basepath = os.getenv("TEST_WORKDIR")
+        workdir_basepath = os.getenv("TEST_WORKDIR", "/tmp")
         workdir = self.get_random_string(10)
         test_workdir = os.path.join(workdir_basepath, workdir)
         os.mkdir(test_workdir)


### PR DESCRIPTION
## Description  
- At Line 2337, the main file, `src/krkn_lib/k8s/krkn_kubernetes.py`, says the `download_path` variable has a default value of `/tmp`. This means it assumes that the path exists. In Linux systems, it exists by default. However, a mistake was made later in the configuration; an error message was raised if the path didn't exist. Why would you assume a path exists by default but then fail if it doesn't? A better approach would be to create that path.

- The test file assumes that the user assigned the path to a `TEST_WORKDIR` environmental variable, but it failed to fall back to the default path specified in the main file. This made the test fail. I've added the default path.

### Previous error message
```bash
test_download_folder_from_pod_as_archive (test_krkn_kubernetes_exec.KrknKubernetesTestsExec) ... ERROR

======================================================================
ERROR: test_download_folder_from_pod_as_archive (test_krkn_kubernetes_exec.KrknKubernetesTestsExec)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/mac/Documents/krkn-lib/src/krkn_lib/tests/test_krkn_kubernetes_exec.py", line 129, in test_download_folder_from_pod_as_archive
    test_workdir = os.path.join(workdir_basepath, workdir)
  File "/usr/local/Cellar/python@3.9/3.9.23/Frameworks/Python.framework/Versions/3.9/lib/python3.9/posixpath.py", line 76, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```
