### PR TITLE
Removing load of kubeconfig

### DIFF
--- a/src/krkn_lib/k8s/pod_monitor/pod_monitor.py
+++ b/src/krkn_lib/k8s/pod_monitor/pod_monitor.py
@@ -1,10 +1,9 @@
-import os
 import re
 from concurrent.futures import Future
 from concurrent.futures.thread import ThreadPoolExecutor
 from functools import partial
 
-from kubernetes import config, watch
+from kubernetes import watch
 from kubernetes.client import V1Pod, CoreV1Api
 
 from krkn_lib.models.pod_monitor.models import (
@@ -13,9 +12,6 @@ from krkn_lib.models.pod_monitor.models import (
     PodEvent,
     PodStatus,
 )
-
-config.load_kube_config(os.path.join(os.environ["HOME"], ".kube/config"))
-
 
 def _select_pods(
     select_partial: partial,


### PR DESCRIPTION
## Description  
Setting kubeconfig separate from in the  k8s kubernetes, causing lots of prow failures 


## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  