### PR TITLE
Adding rehearsal type to prow

### DIFF
--- a/src/krkn_lib/tests/test_utils.py
+++ b/src/krkn_lib/tests/test_utils.py
@@ -426,7 +426,25 @@ class UtilFunctionTests(BaseTest):
         os.environ["JOB_NAME"] = "1953335493844275200"
         ci_job_url = utils.get_ci_job_url()
         print("ci job url" + str(ci_job_url))
-        self.assertIn("prow.ci.openshift.org", ci_job_url)
+        self.assertIn(
+            "prow.ci.openshift.org/view/gs/origin-ci-test", ci_job_url
+        )
+        os.environ["PULL_NUMBER"] = "68493"
+        os.environ["PROW_JOB_ID"] = os.environ["JOB_NAME"] = (
+            "1965813126276321280"
+        )
+        os.environ["JOB_TYPE"] = "presubmit"
+
+        os.environ["BUILD_ID"] = (
+            "rehearse-68493-periodic-ci-redhat-chaos-prow-scripts-main-4.20-nightly-krkn-hub-node-tests-aws-ipsec"  # NOQA
+        )
+
+        ci_job_url = utils.get_ci_job_url()
+        print("ci job url" + str(ci_job_url))
+        self.assertIn(
+            "prow.ci.openshift.org/view/gs/test-platform-results", ci_job_url
+        )
+
         os.environ["PROW_JOB_ID"] = ""
         os.environ["BUILD_URL"] = (
             "https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/kraken/"  # NOQA

--- a/src/krkn_lib/utils/functions.py
+++ b/src/krkn_lib/utils/functions.py
@@ -472,10 +472,26 @@ def get_ci_job_url():
         prow_base_url = (
             "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs"
         )
+        prow_pr_base_url=(
+            "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release" # NOQA
+        )
         task_id = os.getenv("BUILD_ID")
         job_id = os.getenv("JOB_NAME")
-
-        build_url = f"{prow_base_url}/{job_id}/{task_id}"
+        pull_number = os.getenv("PULL_NUMBER")
+        job_type=os.getenv("JOB_TYPE")
+        if job_type == "presubmit" and "pull" in task_id:
+            # Indicates a ci test triggered in PR against source code
+            job_type = "pull"
+        if job_type == "presubmit" and "rehearse" in task_id:
+            # Indicates a rehearsel in PR against openshift/release repo
+            job_type = "pull"
+        # Handle cases where a periodic job iw triggered via pull request
+        if job_type == "periodic" and pull_number:
+          job_type = "pull"
+        if job_type == "pull" :
+            build_url=f"{prow_pr_base_url}/{pull_number}/{task_id}/{job_id}"
+        else:
+            build_url=f"{prow_base_url}/{job_id}/{task_id}"
 
     elif os.getenv("BUILD_URL", ""):
         # Jenkins build url


### PR DESCRIPTION
## Description  
Build url's are not properly rendering when the job is from a rehearsal/pr 

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  