### PR TITLE
[WIP] Adding socks proxy support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -114,7 +114,12 @@ jobs:
 
         run: |
           echo "ELASTIC PASSWORD: $ELASTIC_PASSWORD"
-          poetry run python3 -m coverage run -a -m unittest discover -v src/krkn_lib/tests/
+          poetry run python3 -m coverage run -a -m unittest discover -v src/krkn_lib/tests/ --omit=test_krkn_kubernetes_socks_proxy.py 
+          poetry run python3 -m coverage html
+          poetry run python3 -m coverage json
+      - name: Run tests with coverage with proxy
+        run: |
+          poetry run python3 -m coverage run -a -m unittest discover -v src/krkn_lib/tests/ --include=test_krkn_kubernetes_socks_proxy.py
           poetry run python3 -m coverage html
           poetry run python3 -m coverage json
       - name: Run AWS specific tests with coverage

--- a/poetry.lock
+++ b/poetry.lock
@@ -1492,6 +1492,19 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+groups = ["main"]
+files = [
+    {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},
+    {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
+    {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2084,19 +2097,22 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.20"
+version = "1.26.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 groups = ["main", "test"]
 files = [
-    {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
-    {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
+    {file = "urllib3-1.26.3-py2.py3-none-any.whl", hash = "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80"},
+    {file = "urllib3-1.26.3.tar.gz", hash = "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"},
 ]
 
+[package.dependencies]
+PySocks = {version = ">=1.5.6,<1.5.7 || >1.5.7,<2.0", optional = true, markers = "extra == \"socks\""}
+
 [package.extras]
-brotli = ["brotli (==1.0.9) ; os_name != \"nt\" and python_version < \"3\" and platform_python_implementation == \"CPython\"", "brotli (>=1.0.9) ; python_version >= \"3\" and platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; (os_name != \"nt\" or python_version >= \"3\") and platform_python_implementation != \"CPython\"", "brotlipy (>=0.6.0) ; os_name == \"nt\" and python_version < \"3\""]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress ; python_version == \"2.7\"", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress ; python_version == \"2.7\"", "pyOpenSSL (>=0.14)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -2171,4 +2187,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "79a5e4bc76e69b65d148830571bd14064d5612f26f7d599f604e622722a6c8ec"
+content-hash = "90d92ca025a71160e65d3d27f649a3bdbecf2fa182dbd9c989a939d49d7afab2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -530,14 +530,14 @@ files = [
 
 [[package]]
 name = "elastic-transport"
-version = "8.17.1"
+version = "8.15.1"
 description = "Transport classes and utilities shared among Python Elastic client libraries"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "elastic_transport-8.17.1-py3-none-any.whl", hash = "sha256:192718f498f1d10c5e9aa8b9cf32aed405e469a7f0e9d6a8923431dbb2c59fb8"},
-    {file = "elastic_transport-8.17.1.tar.gz", hash = "sha256:5edef32ac864dca8e2f0a613ef63491ee8d6b8cfb52881fa7313ba9290cac6d2"},
+    {file = "elastic_transport-8.15.1-py3-none-any.whl", hash = "sha256:b5e82ff1679d8c7705a03fd85c7f6ef85d6689721762d41228dd312e34f331fc"},
+    {file = "elastic_transport-8.15.1.tar.gz", hash = "sha256:9cac4ab5cf9402668cf305ae0b7d93ddc0c7b61461d6d1027850db6da9cc5742"},
 ]
 
 [package.dependencies]
@@ -545,7 +545,7 @@ certifi = "*"
 urllib3 = ">=1.26.2,<3"
 
 [package.extras]
-develop = ["aiohttp", "furo", "httpx", "opentelemetry-api", "opentelemetry-sdk", "orjson", "pytest", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "pytest-mock", "requests", "respx", "sphinx (>2)", "sphinx-autodoc-typehints", "trustme"]
+develop = ["aiohttp", "furo", "httpcore (<1.0.6)", "httpx", "opentelemetry-api", "opentelemetry-sdk", "orjson", "pytest", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "pytest-mock", "requests", "respx", "sphinx (>2)", "sphinx-autodoc-typehints", "trustme"]
 
 [[package]]
 name = "elasticsearch"
@@ -1698,20 +1698,21 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.32.3"
+version = "2.32.5"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
-    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
+    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
+    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<4"
+charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
+PySocks = {version = ">=1.5.6,<1.5.7 || >1.5.7", optional = true, markers = "extra == \"socks\""}
 urllib3 = ">=1.21.1,<3"
 
 [package.extras]
@@ -2187,4 +2188,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "90d92ca025a71160e65d3d27f649a3bdbecf2fa182dbd9c989a939d49d7afab2"
+content-hash = "61335d8c04bb1a8b608aed2f889cf4e9d62e2d4813568f7abef94bd8d503da47"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/redhat-chaos/krkn"
 python = "^3.9"
 kubernetes ="34.1.0"
 sphinxnotes-markdown-builder="^0.5.6"
-requests="^2.29.0"
+requests={extras = ["socks"], version = "^2.32.5"}
 kubeconfig = "^1.1.1"
 base64io = "^1.0.3"
 sphinx-rtd-theme = "^1.2.2"
@@ -28,6 +28,7 @@ numpy= "1.26.4"
 deprecation="2.1.0"
 coverage="^7.6.12"
 urllib3 = {version = "1.26.3", extras = ["socks"]}
+elastic-transport = "8.15.1"
 
 [tool.poetry.group.test.dependencies]
 jinja2 = "^3.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requests="^2.29.0"
 kubeconfig = "^1.1.1"
 base64io = "^1.0.3"
 sphinx-rtd-theme = "^1.2.2"
-tzlocal = "5.1"
+tzlocal = "^5.1"
 pytz = "^2023.3"
 PyYAML = "6.0.1"
 prometheus-api-client = "^0.5.4"
@@ -27,6 +27,7 @@ cython = "3.0"
 numpy= "1.26.4"
 deprecation="2.1.0"
 coverage="^7.6.12"
+urllib3 = {version = "1.26.3", extras = ["socks"]}
 
 [tool.poetry.group.test.dependencies]
 jinja2 = "^3.1.2"

--- a/src/krkn_lib/elastic/krkn_elastic.py
+++ b/src/krkn_lib/elastic/krkn_elastic.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import time
 
 import urllib3
 from elasticsearch import Elasticsearch, NotFoundError
+from elastic_transport import RequestsHttpNode
 from elasticsearch_dsl import Search
 
 from krkn_lib.models.elastic.models import (
@@ -46,12 +48,15 @@ class KrknElastic:
             credentials = (
                 (username, password) if username and password else None
             )
+            os.environ['NO_PROXY'] = elastic_url
             self.es = Elasticsearch(
                 f"{elastic_url}:{elastic_port}",
                 http_auth=credentials,
                 verify_certs=verify_certs,
                 ssl_show_warn=False,
+                node_class=RequestsHttpNode,
             )
+            del os.environ['NO_PROXY'] 
         except Exception as e:
             self.safe_logger.error("Failed to initalize elasticsearch: %s" % e)
             raise e

--- a/src/krkn_lib/tests/test_krkn_kubernetes_socks_proxy.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_socks_proxy.py
@@ -1,0 +1,383 @@
+# Created-by: Claude Sonnet 4
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from kubernetes import config
+from urllib3.contrib.socks import SOCKSProxyManager
+
+from krkn_lib.k8s import KrknKubernetes
+
+
+class KrknKubernetesTestsSocksProxy(unittest.TestCase):
+    """Test cases for SOCKS proxy initialization in KrknKubernetes"""
+
+    def test_init_without_socks_proxy(self):
+        """Test initialization without SOCKS proxy
+        (normal HTTP/HTTPS proxy or no proxy)"""
+        # Ensure no socks proxy is set
+        original_http_proxy = os.environ.get("http_proxy")
+        try:
+            # Clear any existing proxy
+            if "http_proxy" in os.environ:
+                del os.environ["http_proxy"]
+
+            # Initialize KrknKubernetes
+            lib_k8s = KrknKubernetes(config.KUBE_CONFIG_DEFAULT_LOCATION)
+
+            # Verify that socks_proxy_manager is not set
+            self.assertIsNone(lib_k8s._KrknKubernetes__socks_proxy_manager)
+
+            # Verify that api_client can be created
+            api_client = lib_k8s.api_client
+            self.assertIsNotNone(api_client)
+
+        finally:
+            # Restore original proxy setting
+            if original_http_proxy:
+                os.environ["http_proxy"] = original_http_proxy
+            elif "http_proxy" in os.environ:
+                del os.environ["http_proxy"]
+
+    @patch("krkn_lib.k8s.krkn_kubernetes.SOCKSProxyManager")
+    @patch("krkn_lib.k8s.krkn_kubernetes.config.load_kube_config")
+    def test_init_with_socks5_proxy(
+        self, mock_load_kube_config, mock_socks_manager
+    ):
+        """Test initialization with SOCKS5 proxy"""
+        # Setup mock
+        mock_socks_instance = MagicMock(spec=SOCKSProxyManager)
+        mock_socks_manager.return_value = mock_socks_instance
+
+        original_http_proxy = os.environ.get("http_proxy")
+        try:
+            # Set SOCKS5 proxy
+            os.environ["http_proxy"] = "socks5://localhost:1080"
+
+            # Initialize KrknKubernetes
+            lib_k8s = KrknKubernetes(config.KUBE_CONFIG_DEFAULT_LOCATION)
+
+            # Verify that SOCKSProxyManager was called with socks5h URL
+            # (the 'h' suffix forces remote DNS resolution)
+            mock_socks_manager.assert_called_once()
+            call_args = mock_socks_manager.call_args
+            self.assertIn("socks5h://localhost:1080", call_args[0][0])
+
+            # Verify that socks_proxy_manager was set
+            self.assertIsNotNone(lib_k8s._KrknKubernetes__socks_proxy_manager)
+
+            # Verify that client config proxy is None (SOCKS uses pool manager)
+            self.assertIsNone(lib_k8s.client_config.proxy)
+            self.assertIsNone(lib_k8s.client_config.proxy_headers)
+
+        finally:
+            # Restore original proxy setting
+            if original_http_proxy:
+                os.environ["http_proxy"] = original_http_proxy
+            elif "http_proxy" in os.environ:
+                del os.environ["http_proxy"]
+
+    @patch("krkn_lib.k8s.krkn_kubernetes.SOCKSProxyManager")
+    @patch("krkn_lib.k8s.krkn_kubernetes.config.load_kube_config")
+    def test_init_with_socks5_proxy_with_credentials(
+        self, mock_load_kube_config, mock_socks_manager
+    ):
+        """Test initialization with SOCKS5 proxy with username and password"""
+        # Setup mock
+        mock_socks_instance = MagicMock(spec=SOCKSProxyManager)
+        mock_socks_manager.return_value = mock_socks_instance
+
+        original_http_proxy = os.environ.get("http_proxy")
+        try:
+            # Set SOCKS5 proxy with credentials
+            os.environ["http_proxy"] = "socks5://user:pass@localhost:1080"
+
+            # Initialize KrknKubernetes
+            lib_k8s = KrknKubernetes(config.KUBE_CONFIG_DEFAULT_LOCATION)
+
+            # Verify that SOCKSProxyManager was called
+            mock_socks_manager.assert_called_once()
+            call_args = mock_socks_manager.call_args
+
+            # Verify that credentials are included in the SOCKS URL
+            self.assertIn("user", call_args[0][0])
+            self.assertIn("pass", call_args[0][0])
+            self.assertIn("socks5h://", call_args[0][0])
+
+            # Verify that socks_proxy_manager was set
+            self.assertIsNotNone(lib_k8s._KrknKubernetes__socks_proxy_manager)
+
+        finally:
+            # Restore original proxy setting
+            if original_http_proxy:
+                os.environ["http_proxy"] = original_http_proxy
+            elif "http_proxy" in os.environ:
+                del os.environ["http_proxy"]
+
+    @patch("krkn_lib.k8s.krkn_kubernetes.SOCKSProxyManager")
+    @patch("krkn_lib.k8s.krkn_kubernetes.config.load_kube_config")
+    def test_init_with_socks4_proxy(
+        self, mock_load_kube_config, mock_socks_manager
+    ):
+        """Test initialization with SOCKS4 proxy"""
+        # Setup mock
+        mock_socks_instance = MagicMock(spec=SOCKSProxyManager)
+        mock_socks_manager.return_value = mock_socks_instance
+
+        original_http_proxy = os.environ.get("http_proxy")
+        try:
+            # Set SOCKS4 proxy
+            os.environ["http_proxy"] = "socks4://localhost:1080"
+
+            # Initialize KrknKubernetes
+            lib_k8s = KrknKubernetes(config.KUBE_CONFIG_DEFAULT_LOCATION)
+
+            # Verify that SOCKSProxyManager was called
+            mock_socks_manager.assert_called_once()
+            call_args = mock_socks_manager.call_args
+
+            # SOCKS4 should also be detected and used
+            self.assertIn("socks", call_args[0][0].lower())
+
+            # Verify that socks_proxy_manager was set
+            self.assertIsNotNone(lib_k8s._KrknKubernetes__socks_proxy_manager)
+
+        finally:
+            # Restore original proxy setting
+            if original_http_proxy:
+                os.environ["http_proxy"] = original_http_proxy
+            elif "http_proxy" in os.environ:
+                del os.environ["http_proxy"]
+
+    @patch("krkn_lib.k8s.krkn_kubernetes.SOCKSProxyManager")
+    @patch("krkn_lib.k8s.krkn_kubernetes.config.load_kube_config")
+    def test_api_client_uses_socks_proxy_manager(
+        self, mock_load_kube_config, mock_socks_manager
+    ):
+        """Test that api_client properly uses SOCKS proxy manager"""
+        # Setup mock
+        mock_socks_instance = MagicMock(spec=SOCKSProxyManager)
+        mock_socks_manager.return_value = mock_socks_instance
+
+        original_http_proxy = os.environ.get("http_proxy")
+        try:
+            # Set SOCKS5 proxy
+            os.environ["http_proxy"] = "socks5://localhost:1080"
+
+            # Initialize KrknKubernetes
+            lib_k8s = KrknKubernetes(config.KUBE_CONFIG_DEFAULT_LOCATION)
+
+            # Access api_client to trigger its creation
+            api_client = lib_k8s.api_client
+
+            # Verify that api_client was created
+            self.assertIsNotNone(api_client)
+
+            # Verify that the pool_manager was replaced
+            # with SOCKS proxy manager
+            self.assertEqual(
+                api_client.rest_client.pool_manager, mock_socks_instance
+            )
+
+        finally:
+            # Restore original proxy setting
+            if original_http_proxy:
+                os.environ["http_proxy"] = original_http_proxy
+            elif "http_proxy" in os.environ:
+                del os.environ["http_proxy"]
+
+    @patch("krkn_lib.k8s.krkn_kubernetes.config.load_kube_config")
+    def test_init_with_regular_http_proxy(self, mock_load_kube_config):
+        """Test initialization with regular HTTP proxy (not SOCKS)"""
+        original_http_proxy = os.environ.get("http_proxy")
+        try:
+            # Set regular HTTP proxy with credentials
+            # Note: The current implementation requires
+            # credentials in the proxy URL
+            os.environ["http_proxy"] = (
+                "http://user:pass@proxy.example.com:8080"
+            )
+
+            # Initialize KrknKubernetes
+            lib_k8s = KrknKubernetes(config.KUBE_CONFIG_DEFAULT_LOCATION)
+
+            # Verify that SOCKS proxy manager is NOT set
+            self.assertIsNone(lib_k8s._KrknKubernetes__socks_proxy_manager)
+
+            # Verify that regular proxy is set in client config
+            self.assertEqual(
+                lib_k8s.client_config.proxy,
+                "http://user:pass@proxy.example.com:8080",
+            )
+
+        finally:
+            # Restore original proxy setting
+            if original_http_proxy:
+                os.environ["http_proxy"] = original_http_proxy
+            elif "http_proxy" in os.environ:
+                del os.environ["http_proxy"]
+
+    @patch("krkn_lib.k8s.krkn_kubernetes.SOCKSProxyManager")
+    @patch("krkn_lib.k8s.krkn_kubernetes.ssl.create_default_context")
+    @patch("krkn_lib.k8s.krkn_kubernetes.config.load_kube_config")
+    def test_socks_proxy_ssl_context_configuration(
+        self, mock_load_kube_config, mock_ssl_context, mock_socks_manager
+    ):
+        """Test that SSL context is properly configured for SOCKS proxy"""
+        # Setup mocks
+        mock_ssl_instance = MagicMock()
+        mock_ssl_context.return_value = mock_ssl_instance
+        mock_socks_instance = MagicMock(spec=SOCKSProxyManager)
+        mock_socks_manager.return_value = mock_socks_instance
+
+        original_http_proxy = os.environ.get("http_proxy")
+        try:
+            # Set SOCKS5 proxy
+            os.environ["http_proxy"] = "socks5://localhost:1080"
+
+            # Initialize KrknKubernetes
+            KrknKubernetes(config.KUBE_CONFIG_DEFAULT_LOCATION)
+
+            # Verify SSL context was created
+            mock_ssl_context.assert_called_once()
+
+            # Verify SOCKSProxyManager was called with SSL context
+            mock_socks_manager.assert_called_once()
+            call_kwargs = mock_socks_manager.call_args[1]
+            self.assertEqual(call_kwargs["ssl_context"], mock_ssl_instance)
+
+            # Verify num_pools and maxsize are set
+            self.assertEqual(call_kwargs["num_pools"], 10)
+            self.assertEqual(call_kwargs["maxsize"], 10)
+
+        finally:
+            # Restore original proxy setting
+            if original_http_proxy:
+                os.environ["http_proxy"] = original_http_proxy
+            elif "http_proxy" in os.environ:
+                del os.environ["http_proxy"]
+
+    @patch("krkn_lib.k8s.krkn_kubernetes.SOCKSProxyManager")
+    @patch("krkn_lib.k8s.krkn_kubernetes.config.load_kube_config")
+    def test_api_client_caching_with_socks_proxy(
+        self, mock_load_kube_config, mock_socks_manager
+    ):
+        """Test that api_client is cached and reused with SOCKS proxy"""
+        # Setup mock
+        mock_socks_instance = MagicMock(spec=SOCKSProxyManager)
+        mock_socks_manager.return_value = mock_socks_instance
+
+        original_http_proxy = os.environ.get("http_proxy")
+        try:
+            # Set SOCKS5 proxy
+            os.environ["http_proxy"] = "socks5://localhost:1080"
+
+            # Initialize KrknKubernetes
+            lib_k8s = KrknKubernetes(config.KUBE_CONFIG_DEFAULT_LOCATION)
+
+            # Access api_client multiple times
+            api_client_1 = lib_k8s.api_client
+            api_client_2 = lib_k8s.api_client
+
+            # Verify they are the same instance (cached)
+            self.assertIs(api_client_1, api_client_2)
+
+        finally:
+            # Restore original proxy setting
+            if original_http_proxy:
+                os.environ["http_proxy"] = original_http_proxy
+            elif "http_proxy" in os.environ:
+                del os.environ["http_proxy"]
+
+    @patch("krkn_lib.k8s.krkn_kubernetes.client.CustomObjectsApi")
+    @patch("krkn_lib.k8s.krkn_kubernetes.SOCKSProxyManager")
+    @patch("krkn_lib.k8s.krkn_kubernetes.config.load_kube_config")
+    def test_custom_object_client_with_socks_proxy(
+        self,
+        mock_load_kube_config,
+        mock_socks_manager,
+        mock_custom_objects_api,
+    ):
+        """Test that custom_object_client works properly with SOCKS proxy"""
+        # Setup mocks
+        mock_socks_instance = MagicMock(spec=SOCKSProxyManager)
+        mock_socks_manager.return_value = mock_socks_instance
+
+        # Mock the custom object client response for cluster version
+        mock_cluster_version_response = {
+            "items": [
+                {
+                    "status": {
+                        "conditions": [
+                            {
+                                "type": "Available",
+                                "message": "Cluster version is 4.14.0",
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+        # Setup the mock custom objects API
+        mock_custom_obj = MagicMock()
+        mock_custom_obj.list_cluster_custom_object.return_value = (
+            mock_cluster_version_response
+        )
+        mock_custom_objects_api.return_value = mock_custom_obj
+
+        original_http_proxy = os.environ.get("http_proxy")
+        try:
+            # Set SOCKS5 proxy
+            os.environ["http_proxy"] = "socks5://localhost:1080"
+
+            # Initialize KrknKubernetes
+            lib_k8s = KrknKubernetes(config.KUBE_CONFIG_DEFAULT_LOCATION)
+
+            # Call the method that uses custom_object_client
+            result = lib_k8s.custom_object_client.list_cluster_custom_object(
+                "config.openshift.io",
+                "v1",
+                "clusterversions",
+            )
+
+            mock_custom_obj = mock_custom_obj.list_cluster_custom_object
+            # Verify the call was made
+            mock_custom_obj.assert_called_once_with(
+                "config.openshift.io",
+                "v1",
+                "clusterversions",
+            )
+
+            # Verify the result
+            self.assertIsNotNone(result)
+            self.assertIn("items", result)
+            self.assertEqual(len(result["items"]), 1)
+            self.assertEqual(
+                result["items"][0]["status"]["conditions"][0]["message"],
+                "Cluster version is 4.14.0",
+            )
+
+            # Verify that the SOCKS proxy manager was set up
+            self.assertIsNotNone(lib_k8s._KrknKubernetes__socks_proxy_manager)
+
+            # Verify the api_client is using the SOCKS proxy manager
+            api_client = lib_k8s.api_client
+            self.assertEqual(
+                api_client.rest_client.pool_manager, mock_socks_instance
+            )
+
+            # Verify that CustomObjectsApi was instantiated with the api_client
+            mock_custom_objects_api.assert_called_with(api_client)
+
+        finally:
+            # Restore original proxy setting
+            if original_http_proxy:
+                os.environ["http_proxy"] = original_http_proxy
+            elif "http_proxy" in os.environ:
+                del os.environ["http_proxy"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/krkn_lib/tests/test_krkn_prometheus_socks_proxy.py
+++ b/src/krkn_lib/tests/test_krkn_prometheus_socks_proxy.py
@@ -1,0 +1,246 @@
+# Integration tests for KrknPrometheus with SOCKS5 proxy
+#
+# This test file contains both unit tests (using mocks) and integration tests
+# (requiring real services).
+#
+# Unit tests (always run):
+# - test_init_without_socks_proxy
+# - test_init_with_socks5_proxy
+# - test_init_with_socks5_proxy_with_credentials
+# - test_init_with_regular_http_proxy
+#
+# Integration tests (require running services):
+# - test_query_prometheus_with_socks5_proxy_real_connection
+#   Requires: Prometheus at localhost:9090 and SOCKS5 proxy at localhost:1080
+#
+# - test_query_prometheus_with_socks5_proxy_with_auth
+#   Requires: Prometheus, authenticated SOCKS5 proxy, and env vars:
+#   SOCKS_PROXY_USER and SOCKS_PROXY_PASS
+#
+# To set up a local SOCKS5 proxy for testing:
+# 1. Using SSH tunnel: ssh -D 1080 -N username@remote-host
+# 2. Using dante-server or other SOCKS proxy software
+#
+# Run unit tests only:
+#   python -m unittest src.krkn_lib.tests.test_krkn_prometheus_socks_proxy \
+#     -k "test_init"
+#
+# Run all tests (including integration):
+#   python -m unittest src.krkn_lib.tests.test_krkn_prometheus_socks_proxy
+
+import datetime
+import logging
+import os
+import socket
+import unittest
+from unittest.mock import MagicMock, patch
+
+from krkn_lib.prometheus.krkn_prometheus import KrknPrometheus
+
+
+class TestKrknPrometheusSocksProxy(unittest.TestCase):
+    """Test cases for SOCKS proxy functionality in KrknPrometheus"""
+
+    url = "http://localhost:9090"
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test environment"""
+        cls.original_http_proxy = os.environ.get("http_proxy")
+        cls.original_https_proxy = os.environ.get("https_proxy")
+        cls.original_HTTP_PROXY = os.environ.get("HTTP_PROXY")
+        cls.original_HTTPS_PROXY = os.environ.get("HTTPS_PROXY")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Restore original environment"""
+        # Restore original proxy settings
+        if cls.original_http_proxy:
+            os.environ["http_proxy"] = cls.original_http_proxy
+        elif "http_proxy" in os.environ:
+            del os.environ["http_proxy"]
+
+        if cls.original_https_proxy:
+            os.environ["https_proxy"] = cls.original_https_proxy
+        elif "https_proxy" in os.environ:
+            del os.environ["https_proxy"]
+
+        if cls.original_HTTP_PROXY:
+            os.environ["HTTP_PROXY"] = cls.original_HTTP_PROXY
+        elif "HTTP_PROXY" in os.environ:
+            del os.environ["HTTP_PROXY"]
+
+        if cls.original_HTTPS_PROXY:
+            os.environ["HTTPS_PROXY"] = cls.original_HTTPS_PROXY
+        elif "HTTPS_PROXY" in os.environ:
+            del os.environ["HTTPS_PROXY"]
+
+    def setUp(self):
+        """Clear proxy environment before each test"""
+        for key in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"]:
+            if key in os.environ:
+                del os.environ[key]
+
+    @patch("krkn_lib.prometheus.krkn_prometheus.PrometheusConnect")
+    def test_init_without_socks_proxy(self, mock_prom_connect):
+        """Test initialization without SOCKS proxy"""
+        mock_prom_connect.return_value = MagicMock()
+
+        # Initialize without proxy
+        prom_cli = KrknPrometheus(self.url)
+
+        # Verify PrometheusConnect was called
+        mock_prom_connect.assert_called_once()
+        call_args = mock_prom_connect.call_args
+
+        # Proxy should be None
+        self.assertIn("proxy", call_args[1])
+        proxy_config = call_args[1]["proxy"]
+        self.assertIsNone(proxy_config["http"])
+        self.assertIsNone(proxy_config["https"])
+
+
+    def test_query_prometheus_with_socks5_proxy_real_connection(self):
+        """
+        Integration test: Query Prometheus through SOCKS5 proxy
+
+        This test requires:
+        1. A running Prometheus server at http://localhost:9090
+        2. A running SOCKS5 proxy at localhost:1080
+
+        The test will be skipped if either service is unavailable.
+        """
+        # Check if Prometheus is available
+        prom_available = self._check_service_available("localhost", 9090)
+        if not prom_available:
+            self.skipTest("Prometheus server not available at localhost:9090")
+
+        # Check if SOCKS proxy is available
+        socks_available = self._check_service_available("localhost", 1080)
+        if not socks_available:
+            self.skipTest("SOCKS5 proxy not available at localhost:1080")
+
+        try:
+            # Set SOCKS5 proxy
+            os.environ["http_proxy"] = "socks5://127.0.0.1:1080"
+
+            # Initialize Prometheus client with SOCKS proxy
+            prom_cli = KrknPrometheus(self.url)
+
+            # Attempt a simple query
+            query = "up"
+            result = prom_cli.process_query(query)
+
+            # Verify we got a response
+            self.assertIsNotNone(result)
+            self.assertIsInstance(result, list)
+
+            # If Prometheus has any targets, we should get results
+            logging.info(
+                f"Successfully queried Prometheus through SOCKS5 proxy. "
+                f"Results: {len(result)} metrics"
+            )
+
+            # Try a time-range query
+            start_time = datetime.datetime.now() - datetime.timedelta(minutes=5)
+            end_time = datetime.datetime.now()
+
+            range_result = prom_cli.process_prom_query_in_range(
+                query, start_time, end_time, granularity=60
+            )
+
+            self.assertIsNotNone(range_result)
+            self.assertIsInstance(range_result, list)
+
+            logging.info(
+                f"Successfully queried Prometheus time range through "
+                f"SOCKS5 proxy. Results: {len(range_result)} metrics"
+            )
+
+        except Exception as e:
+            self.fail(
+                f"Failed to query Prometheus through SOCKS5 proxy: {str(e)}"
+            )
+
+    def test_query_prometheus_with_socks5_proxy_with_auth(self):
+        """
+        Integration test: Query Prometheus through authenticated SOCKS5 proxy
+
+        This test requires:
+        1. A running Prometheus server at http://localhost:9090
+        2. A running SOCKS5 proxy at localhost:1080 with authentication
+
+        The test will be skipped if either service is unavailable.
+        """
+        # Check if Prometheus is available
+        prom_available = self._check_service_available("localhost", 9090)
+        if not prom_available:
+            self.skipTest("Prometheus server not available at localhost:9090")
+
+        # Check if SOCKS proxy is available
+        socks_available = self._check_service_available("localhost", 1080)
+        if not socks_available:
+            self.skipTest("SOCKS5 proxy not available at localhost:1080")
+
+        # Check if auth is configured via environment
+        socks_user = os.environ.get("SOCKS_PROXY_USER")
+        socks_pass = os.environ.get("SOCKS_PROXY_PASS")
+
+        if not socks_user or not socks_pass:
+            self.skipTest(
+                "SOCKS5 proxy authentication credentials not configured. "
+                "Set SOCKS_PROXY_USER and SOCKS_PROXY_PASS environment "
+                "variables to run this test."
+            )
+
+        try:
+            # Set SOCKS5 proxy with authentication
+            os.environ["http_proxy"] = (
+                f"socks5://{socks_user}:{socks_pass}@127.0.0.1:1080"
+            )
+
+            # Initialize Prometheus client with authenticated SOCKS proxy
+            prom_cli = KrknPrometheus(self.url)
+
+            # Attempt a simple query
+            query = "up"
+            result = prom_cli.process_query(query)
+
+            # Verify we got a response
+            self.assertIsNotNone(result)
+            self.assertIsInstance(result, list)
+
+            logging.info(
+                f"Successfully queried Prometheus through authenticated "
+                f"SOCKS5 proxy. Results: {len(result)} metrics"
+            )
+
+        except Exception as e:
+            self.fail(
+                f"Failed to query Prometheus through authenticated "
+                f"SOCKS5 proxy: {str(e)}"
+            )
+
+    @staticmethod
+    def _check_service_available(host, port, timeout=2):
+        """
+        Check if a service is available at the given host and port
+
+        :param host: hostname or IP address
+        :param port: port number
+        :param timeout: connection timeout in seconds
+        :return: True if service is available, False otherwise
+        """
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        try:
+            result = sock.connect_ex((host, port))
+            return result == 0
+        except socket.error:
+            return False
+        finally:
+            sock.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description  
After Jose hit [this issue](https://github.com/krkn-chaos/cerberus/issues/215) in cerberus, we need to also add this change to krkn to be able to run krkn workloads on baremetal jetlag instances in the future 


Adding urllib3[socks] needed a newer urllib3 version than other packages supported so had to update those as well 


```
Because no versions of urllib3 match >2.5.0,<3.0.0
 and urllib3[socks] (2.5.0) depends on urllib3 (2.5.0), urllib3[socks] (>=2.5.0,<3.0.0) requires urllib3 (2.5.0).
And because elasticsearch (7.13.4) depends on urllib3 (>=1.21.1,<2), urllib3[socks] (>=2.5.0,<3.0.0) is incompatible with elasticsearch (7.13.4).
So, because krkn-lib depends on both elasticsearch (7.13.4) and urllib3[socks] (^2.5.0), version solving failed.

Because no versions of urllib3 match >2.5.0,<3.0.0
 and urllib3[socks] (2.5.0) depends on urllib3 (2.5.0), urllib3[socks] (>=2.5.0,<3.0.0) requires urllib3 (2.5.0).
And because kubernetes (28.1.0) depends on urllib3 (>=1.24.2,<2.0), urllib3[socks] (>=2.5.0,<3.0.0) is incompatible with kubernetes (28.1.0).
So, because krkn-lib depends on both kubernetes (28.1.0) and urllib3[socks] (^2.5.0), version solving failed.
```

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  