### PR TITLE
Adding new ip address for when vm restarts or is killed

### DIFF
--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -173,7 +173,6 @@ class KrknKubernetes:
             # such as INFO, WARNING, or ERROR
             # This will effectively disable DEBUG level messages.
             kubernetes_logger.setLevel(logging.INFO)
-
         except OSError:
             raise Exception(
                 "Invalid kube-config file: {0}. "

--- a/src/krkn_lib/models/elastic/models.py
+++ b/src/krkn_lib/models/elastic/models.py
@@ -118,6 +118,7 @@ class ElasticHealthChecks(InnerDoc):
 class ElasticVirtChecks(InnerDoc):
     vm_name = Text()
     ip_address = Text()
+    new_ip_address = Text()
     namespace = Text()
     node_name = Text()
     status = Boolean()
@@ -243,6 +244,7 @@ class ElasticChaosRunTelemetry(Document):
                 ElasticVirtChecks(
                     vm_name=info.vm_name,
                     ip_address=info.ip_address,
+                    new_ip_address=info.new_ip_address,
                     namespace=info.namespace,
                     node_name=info.node_name,
                     status=info.status,

--- a/src/krkn_lib/models/telemetry/models.py
+++ b/src/krkn_lib/models/telemetry/models.py
@@ -436,6 +436,10 @@ class VirtCheck:
     """
     Vm ip address
     """
+    new_ip_address: str
+    """
+    New Ip address when vm restarts
+    """
     namespace: str
     """
     Namespace
@@ -471,6 +475,7 @@ class VirtCheck:
             self.start_timestamp = json_dict.get("start_timestamp", "")
             self.end_timestamp = json_dict.get("end_timestamp", "")
             self.duration = json_dict.get("duration", "")
+            self.new_ip_address = json_dict.get("new_ip_address", "")
 
 
 @dataclass(order=False)

--- a/src/krkn_lib/tests/base_test.py
+++ b/src/krkn_lib/tests/base_test.py
@@ -583,6 +583,7 @@ class BaseTest(unittest.TestCase):
                     "start_timestamp": "2025-03-12T14:57:34.555878",
                     "end_timestamp": "2025-03-12T14:57:54.904352",
                     "duration": 20.348474,
+                    "new_ip_address": ""
                 },
                 {
                     "node_name": "h27-r660",
@@ -593,6 +594,7 @@ class BaseTest(unittest.TestCase):
                     "start_timestamp": "2025-03-12T14:57:34.759105",
                     "end_timestamp": "2025-03-12T14:57:54.904352",
                     "duration": 20.145247,
+                    "new_ip_address": ""
                 },
                 {
                     "node_name": "h10-r660",
@@ -603,6 +605,7 @@ class BaseTest(unittest.TestCase):
                     "start_timestamp": "2025-03-12T14:57:35.308957",
                     "end_timestamp": "2025-03-12T14:57:54.904352",
                     "duration": 19.595395,
+                    "new_ip_address": "0.0.0.3"
                 },
             ],
             "total_node_count": 3,

--- a/src/krkn_lib/tests/test_krkn_elastic_models.py
+++ b/src/krkn_lib/tests/test_krkn_elastic_models.py
@@ -223,6 +223,12 @@ class TestKrknElasticModels(BaseTest):
             elastic_telemetry.virt_checks[0].ip_address, "0.0.0.0"
         )
         self.assertEqual(
+            elastic_telemetry.virt_checks[0].new_ip_address, ""
+        )
+        self.assertEqual(
+            elastic_telemetry.virt_checks[2].new_ip_address, "0.0.0.3"
+        )
+        self.assertEqual(
             elastic_telemetry.virt_checks[0].namespace, "benchmark-runner"
         )
         self.assertEqual(


### PR DESCRIPTION
## Description  
Adding new ip address for tracking vm once its restarted

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  