### PR TITLE
Info kubernetes logging

### DIFF
--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -166,6 +166,13 @@ class KrknKubernetes:
 
             client.Configuration.set_default(self.client_config)
             self.watch_resource = watch.Watch()
+            # Get the logger for the kubernetes client
+            kubernetes_logger = logging.getLogger('kubernetes')
+
+            # Set the logging level to a higher level than DEBUG, 
+            # such as INFO, WARNING, or ERROR
+            # This will effectively disable DEBUG level messages.
+            kubernetes_logger.setLevel(logging.INFO)
 
         except OSError:
             raise Exception(


### PR DESCRIPTION
## Description  
Want only kubernetes info logging, even when krkn debug log level is on. Kubernetes spits out huge jsons thats hard to see if krkn debug log level is on

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  