### PR TITLE
Pod monitor cancellation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,14 +133,13 @@ jobs:
           poetry run python3 -m coverage run -a -m unittest discover -v src/krkn_lib/aws_tests/
       
       - name: Combine coverage and publish
-        if: ${{ success() || failure() }}
+        if: ${{ always() }}
         run: |
           poetry run python3 -m coverage html
           poetry run python3 -m coverage json
 
       - name: Publish coverage report to job summary
-    
-        if: ${{ matrix.python-version == '3.9'}}
+        if: ${{ always() }}
         run: |
           poetry run html2text --ignore-images --ignore-links -b 0 htmlcov/index.html >> $GITHUB_STEP_SUMMARY
       - name: Update version number
@@ -150,12 +149,14 @@ jobs:
         run: |
           poetry build
       - name: Upload json coverage
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage.json
           path: coverage.json
           if-no-files-found: error
       - name: Upload dist artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: dist

--- a/src/krkn_lib/k8s/pod_monitor/pod_monitor.py
+++ b/src/krkn_lib/k8s/pod_monitor/pod_monitor.py
@@ -1,4 +1,7 @@
+import logging
 import re
+import threading
+import time
 from concurrent.futures import Future
 from concurrent.futures.thread import ThreadPoolExecutor
 from functools import partial
@@ -47,67 +50,148 @@ def _monitor_pods(
     max_timeout: int,
     name_pattern: str = None,
     namespace_pattern: str = None,
+    stop_event=None,
 ) -> PodsSnapshot:
     w = watch.Watch(return_type=V1Pod)
     deleted_parent_pods = []
     restored_pods = []
     cluster_restored = False
-    for event in w.stream(monitor_partial, timeout_seconds=max_timeout):
-        match_name = True
-        match_namespace = True
-        event_type = event["type"]
-        pod = event["object"]
+    start_time = time.time()
 
-        if namespace_pattern:
-            match = re.match(namespace_pattern, pod.metadata.namespace)
-            match_namespace = match is not None
-        if name_pattern:
-            match = re.match(name_pattern, pod.metadata.name)
-            match_name = match is not None
+    # Use a shorter timeout for each iteration to check stop_event
+    # more frequently. This allows cancellation to be detected
+    # within 5 seconds instead of waiting for max_timeout
+    stream_timeout = 5  # Check for cancellation every 5 seconds
 
-        if match_name and match_namespace:
-            pod_event = PodEvent()
-            if event_type == "MODIFIED":
-                if pod.metadata.deletion_timestamp is not None:
-                    pod_event.status = PodStatus.DELETION_SCHEDULED
-                    deleted_parent_pods.append(pod.metadata.name)
-                elif _is_pod_ready(pod):
-                    pod_event.status = PodStatus.READY
-                    # if there are at least the same number of ready
-                    # pods as the snapshot.initial_pods set we assume that
-                    # the cluster is restored to the initial condition
-                    restored_pods.append(pod.metadata.name)
-                    if len(restored_pods) >= len(snapshot.initial_pods):
-                        cluster_restored = True
-                else:
-                    pod_event.status = PodStatus.NOT_READY
+    def _check_cancel():
+        """Helper function to check if cancellation was requested"""
+        if stop_event and stop_event.is_set():
+            logging.info(
+                "Pod monitoring cancellation detected, stopping watch"
+            )
+            w.stop()
+            return True
+        return False
 
-            elif event_type == "DELETED":
-                pod_event.status = PodStatus.DELETED
-            elif event_type == "ADDED":
-                pod_event.status = PodStatus.ADDED
+    def _check_timeout():
+        """Helper function to check if max_timeout has been exceeded"""
+        elapsed = time.time() - start_time
+        if elapsed >= max_timeout:
+            logging.info(
+                f"Pod monitoring reached max timeout of {max_timeout} seconds"
+            )
+            w.stop()
+            return True
+        return False
 
-            if pod_event.status == PodStatus.ADDED:
-                snapshot.added_pods.append(pod.metadata.name)
-                # in case a pod is respawn with the same name
-                # the dictionary must not be reinitialized
-                if pod.metadata.name not in snapshot.pods:
-                    snapshot.pods[pod.metadata.name] = MonitoredPod()
-                    snapshot.pods[pod.metadata.name].name = pod.metadata.name
-                    snapshot.pods[pod.metadata.name].namespace = (
-                        pod.metadata.namespace
-                    )
-            # skips events out of the snapshot
-            if pod.metadata.name in snapshot.pods:
-                snapshot.pods[pod.metadata.name].status_changes.append(
-                    pod_event
-                )
-            # this flag is set when all the pods
-            # that has been deleted or not ready
-            # have been restored, if True the
-            # monitoring is stopeed earlier
-            if cluster_restored:
-                w.stop()
+    try:
+        while True:
+            # Check for cancellation before starting each stream iteration
+            if _check_cancel():
+                break
+
+            # Check if we've exceeded the max timeout
+            if _check_timeout():
+                break
+
+            # Calculate remaining timeout for this iteration
+            elapsed = time.time() - start_time
+            remaining_timeout = max_timeout - elapsed
+            if remaining_timeout <= 0:
+                break
+
+            # Use the shorter of remaining_timeout or stream_timeout
+            current_timeout = min(stream_timeout, remaining_timeout)
+
+            # Stream with shorter timeout to allow frequent cancellation checks
+            for event in w.stream(
+                monitor_partial, timeout_seconds=current_timeout
+            ):
+                # Check if stopped at the start of each iteration
+                if _check_cancel():
+                    break
+
+                match_name = True
+                match_namespace = True
+                event_type = event["type"]
+                pod = event["object"]
+
+                if namespace_pattern:
+                    match = re.match(namespace_pattern, pod.metadata.namespace)
+                    match_namespace = match is not None
+                if name_pattern:
+                    match = re.match(name_pattern, pod.metadata.name)
+                    match_name = match is not None
+
+                if match_name and match_namespace:
+                    pod_event = PodEvent()
+                    if event_type == "MODIFIED":
+                        if pod.metadata.deletion_timestamp is not None:
+                            pod_event.status = PodStatus.DELETION_SCHEDULED
+                            deleted_parent_pods.append(pod.metadata.name)
+                        elif _is_pod_ready(pod):
+                            pod_event.status = PodStatus.READY
+                            # if there are at least the same number of ready
+                            # pods as the snapshot.initial_pods set we assume
+                            # that the cluster is restored to the initial
+                            # condition
+                            restored_pods.append(pod.metadata.name)
+                            if len(restored_pods) >= len(
+                                snapshot.initial_pods
+                            ):
+                                cluster_restored = True
+                        else:
+                            pod_event.status = PodStatus.NOT_READY
+
+                    elif event_type == "DELETED":
+                        pod_event.status = PodStatus.DELETED
+                    elif event_type == "ADDED":
+                        pod_event.status = PodStatus.ADDED
+
+                    if pod_event.status == PodStatus.ADDED:
+                        snapshot.added_pods.append(pod.metadata.name)
+                        # in case a pod is respawn with the same name
+                        # the dictionary must not be reinitialized
+                        if pod.metadata.name not in snapshot.pods:
+                            snapshot.pods[pod.metadata.name] = MonitoredPod()
+                            snapshot.pods[pod.metadata.name].name = (
+                                pod.metadata.name
+                            )
+                            snapshot.pods[pod.metadata.name].namespace = (
+                                pod.metadata.namespace
+                            )
+                    # skips events out of the snapshot
+                    if pod.metadata.name in snapshot.pods:
+                        snapshot.pods[pod.metadata.name].status_changes.append(
+                            pod_event
+                        )
+
+                    # Check for cancellation after processing each event
+                    if _check_cancel():
+                        break
+
+                    # this flag is set when all the pods that has been
+                    # deleted or not ready have been restored, if True
+                    # the monitoring is stopped earlier
+                    if cluster_restored:
+                        logging.info(
+                            "Cluster restored, stopping pod monitoring"
+                        )
+                        w.stop()
+                        break
+
+            # If we break out of the inner for loop, check why and
+            # break outer loop if needed
+            if _check_cancel() or cluster_restored:
+                break
+
+    except Exception as e:
+        # If cancellation was requested, this is expected
+        if stop_event and stop_event.is_set():
+            logging.info("Pod monitoring stopped due to cancellation")
+        else:
+            logging.error(f"Error during pod monitoring: {e}")
+            raise
 
     return snapshot
 
@@ -133,23 +217,23 @@ def select_and_monitor_by_label(
     v1_client: CoreV1Api,
 ) -> Future:
     """
-    Monitors all the pods identified
-    by a label selector and collects infos about the
-    pods recovery after a kill scenario while the scenario is running.
+    Monitors all the pods identified by a label selector and collects
+    infos about the pods recovery after a kill scenario while the
+    scenario is running.
 
-    :param label_selector: the label selector used
-        to filter the pods to monitor (must be the
-        same used in `select_pods_by_label`)
-    :param max_timeout: the expected time the pods should take
-        to recover. If the killed pods are replaced in this time frame,
+    :param label_selector: the label selector used to filter the pods
+        to monitor (must be the same used in `select_pods_by_label`)
+    :param max_timeout: the expected time the pods should take to
+        recover. If the killed pods are replaced in this time frame,
         but they didn't reach the Ready State, they will be marked as
         unrecovered. If during the time frame the pods are not replaced
         at all the error field of the PodsStatus structure will be
         valorized with an exception.
     :param v1_client: kubernetes V1Api client
     :return:
-        a future which result (PodsSnapshot) must be
-        gathered to obtain the pod infos.
+        a future which result (PodsSnapshot) must be gathered to obtain
+        the pod infos. Call cancel() on the future to stop monitoring
+        early.
 
     """
     select_partial = partial(
@@ -163,6 +247,7 @@ def select_and_monitor_by_label(
         resource_version=snapshot.resource_version,
         label_selector=label_selector,
     )
+    stop_event = threading.Event()
     pool = ThreadPoolExecutor(max_workers=1)
     future = pool.submit(
         _monitor_pods,
@@ -171,7 +256,18 @@ def select_and_monitor_by_label(
         max_timeout,
         name_pattern=None,
         namespace_pattern=None,
+        stop_event=stop_event,
     )
+    # Store stop_event on the future so cancel() can trigger it
+    future._stop_event = stop_event
+    # Override cancel to also set the stop event
+    original_cancel = future.cancel
+
+    def cancel_with_stop():
+        stop_event.set()
+        return original_cancel()
+
+    future.cancel = cancel_with_stop
     return future
 
 
@@ -182,18 +278,17 @@ def select_and_monitor_by_name_pattern_and_namespace_pattern(
     v1_client: CoreV1Api,
 ):
     """
-    Monitors all the pods identified by a pod name regex pattern
-    and a namespace regex pattern, that collects infos about the
-    pods recovery after a kill scenario while the scenario is running.
+    Monitors all the pods identified by a pod name regex pattern and a
+    namespace regex pattern, that collects infos about the pods
+    recovery after a kill scenario while the scenario is running.
     Raises an exception if the regex format is not correct.
 
-    :param pod_name_pattern: a regex representing the
-        pod name pattern used to filter the pods to be monitored
-        (must be the same used in
-        `select_pods_by_name_pattern_and_namespace_pattern`)
+    :param pod_name_pattern: a regex representing the pod name pattern
+        used to filter the pods to be monitored (must be the same used
+        in `select_pods_by_name_pattern_and_namespace_pattern`)
     :param namespace_pattern: a regex representing the namespace
-        pattern used to filter the pods to be monitored
-        (must be the same used in
+        pattern used to filter the pods to be monitored (must be the
+        same used in
         `select_pods_by_name_pattern_and_namespace_pattern`)
     :param max_timeout: the expected time the pods should take to
         recover. If the killed pods are replaced in this time frame,
@@ -203,8 +298,8 @@ def select_and_monitor_by_name_pattern_and_namespace_pattern(
         valorized with an exception.
     :param v1_client: kubernetes V1Api client
     :return:
-        a future which result (PodsSnapshot) must be
-        gathered to obtain the pod infos.
+        a future which result (PodsSnapshot) must be gathered to
+        obtain the pod infos.
 
     """
     try:
@@ -230,6 +325,7 @@ def select_and_monitor_by_name_pattern_and_namespace_pattern(
         v1_client.list_pod_for_all_namespaces,
         resource_version=snapshot.resource_version,
     )
+    stop_event = threading.Event()
     pool = ThreadPoolExecutor(max_workers=1)
     future = pool.submit(
         _monitor_pods,
@@ -238,7 +334,18 @@ def select_and_monitor_by_name_pattern_and_namespace_pattern(
         max_timeout,
         name_pattern=pod_name_pattern,
         namespace_pattern=namespace_pattern,
+        stop_event=stop_event,
     )
+    # Store stop_event on the future so cancel() can trigger it
+    future._stop_event = stop_event
+    # Override cancel to also set the stop event
+    original_cancel = future.cancel
+
+    def cancel_with_stop():
+        stop_event.set()
+        return original_cancel()
+
+    future.cancel = cancel_with_stop
     return future
 
 
@@ -249,29 +356,27 @@ def select_and_monitor_by_namespace_pattern_and_label(
     max_timeout=30,
 ):
     """
-    Monitors all the pods identified
-    by a namespace regex pattern
-    and a pod label selector, that collects infos about the
-    pods recovery after a kill scenario while the scenario is running.
-    Raises an exception if the regex format is not correct.
+    Monitors all the pods identified by a namespace regex pattern and
+    a pod label selector, that collects infos about the pods recovery
+    after a kill scenario while the scenario is running. Raises an
+    exception if the regex format is not correct.
 
-    :param label_selector: the label selector used to filter
-        the pods to monitor (must be the same used in
-        `select_pods_by_label`)
+    :param label_selector: the label selector used to filter the pods
+        to monitor (must be the same used in `select_pods_by_label`)
     :param v1_client: kubernetes V1Api client
     :param namespace_pattern: a regex representing the namespace
-        pattern used to filter the pods to be monitored (must be
-        the same used
-        in `select_pods_by_name_pattern_and_namespace_pattern`)
-    :param max_timeout: the expected time the pods should take to recover.
-        If the killed pods are replaced in this time frame, but they
-        didn't reach the Ready State, they will be marked as unrecovered.
-        If during the time frame the pods are not replaced
+        pattern used to filter the pods to be monitored (must be the
+        same used in
+        `select_pods_by_name_pattern_and_namespace_pattern`)
+    :param max_timeout: the expected time the pods should take to
+        recover. If the killed pods are replaced in this time frame,
+        but they didn't reach the Ready State, they will be marked as
+        unrecovered. If during the time frame the pods are not replaced
         at all the error field of the PodsStatus structure will be
         valorized with an exception.
     :return:
-        a future which result (PodsSnapshot) must be
-        gathered to obtain the pod infos.
+        a future which result (PodsSnapshot) must be gathered to obtain
+        the pod infos.
 
     """
     try:
@@ -293,6 +398,7 @@ def select_and_monitor_by_namespace_pattern_and_label(
         resource_version=snapshot.resource_version,
         label_selector=label_selector,
     )
+    stop_event = threading.Event()
     pool = ThreadPoolExecutor(max_workers=1)
     future = pool.submit(
         _monitor_pods,
@@ -301,5 +407,16 @@ def select_and_monitor_by_namespace_pattern_and_label(
         max_timeout,
         name_pattern=None,
         namespace_pattern=namespace_pattern,
+        stop_event=stop_event,
     )
+    # Store stop_event on the future so cancel() can trigger it
+    future._stop_event = stop_event
+    # Override cancel to also set the stop event
+    original_cancel = future.cancel
+
+    def cancel_with_stop():
+        stop_event.set()
+        return original_cancel()
+
+    future.cancel = cancel_with_stop
     return future

--- a/src/krkn_lib/tests/test_krkn_kubernetes_pods_monitor.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_pods_monitor.py
@@ -515,3 +515,310 @@ class TestKrknKubernetesPodsMonitor(BaseTest):
         end_time = time.time()
 
         self.assertGreaterEqual((end_time - start_time), monitor_timeout)
+
+    def test_monitor_cancel_by_label(self):
+        # Test that cancel() properly stops monitoring and returns quickly
+        namespace = "test-ns-cancel-1-" + self.get_random_string(10)
+        delayed_1 = "delayed-cancel-1-" + self.get_random_string(10)
+        delayed_2 = "delayed-cancel-1-" + self.get_random_string(10)
+        label = "readiness-" + self.get_random_string(5)
+        self.deploy_namespace(namespace, [])
+        self.deploy_delayed_readiness_pod(delayed_1, namespace, 0, label)
+        self.deploy_delayed_readiness_pod(delayed_2, namespace, 0, label)
+
+        while not self.lib_k8s.is_pod_running(
+            delayed_1, namespace
+        ) and not self.lib_k8s.is_pod_running(delayed_2, namespace):
+            time.sleep(1)
+            continue
+        time.sleep(3)
+
+        monitor_timeout = 120  # Long timeout to test cancellation
+        cancel_delay = 1  # Cancel after 1 second
+
+        start_time = time.time()
+        future = select_and_monitor_by_label(
+            label_selector=f"test={label}",
+            max_timeout=monitor_timeout,
+            v1_client=self.lib_k8s.cli,
+        )
+
+        # Wait a bit then cancel
+        time.sleep(cancel_delay)
+        cancel_start = time.time()
+        future.cancel()
+
+        # Wait for future to finish (may take up to 5 seconds due to
+        # stream_timeout)
+        max_wait_time = 10  # Allow up to 10 seconds for cancellation
+        wait_start = time.time()
+        while not future.done():
+            if time.time() - wait_start > max_wait_time:
+                self.fail("Future did not complete after cancellation")
+            time.sleep(0.1)
+        cancel_end = time.time()
+
+        # Get the snapshot result (should have partial data)
+        # The future should complete normally, not raise CancelledError
+        try:
+            snapshot = future.result(timeout=1)
+        except Exception as e:
+            # If cancelled, the monitoring should still have completed
+            # normally with partial data
+            self.fail(f"Future.result() raised exception: {e}")
+
+        end_time = time.time()
+        pods_status = snapshot.get_pods_status()
+
+        # Verify cancellation happened within reasonable time
+        # (stream_timeout is 5 seconds, so allow up to 7 seconds total)
+        total_time = end_time - start_time
+        cancel_time = cancel_end - cancel_start
+
+        self.assertLess(
+            total_time, 8, "Cancellation should complete within 8 seconds"
+        )
+        self.assertLess(
+            cancel_time, 7,
+            "Future should finish within 7 seconds after cancel()"
+        )
+
+        # Verify we can still get pods status (may be empty or partial)
+        self.assertIsNotNone(pods_status)
+        self.assertIsNotNone(pods_status.recovered)
+        self.assertIsNotNone(pods_status.unrecovered)
+
+        self.background_delete_pod(delayed_1, namespace)
+        self.background_delete_pod(delayed_2, namespace)
+        self.background_delete_ns(namespace)
+
+    def test_monitor_cancel_by_name_pattern_and_namespace_pattern(self):
+        # Test cancellation with name pattern and namespace pattern monitoring
+        namespace_random_pattern = (
+            "test-ns-cancel-2-" + self.get_random_string(3)
+        )
+        namespace = f"{namespace_random_pattern}-" + self.get_random_string(10)
+        delayed_1 = "delayed-cancel-2-" + self.get_random_string(10)
+        delayed_2 = "delayed-cancel-2-" + self.get_random_string(10)
+        label = "readiness-" + self.get_random_string(5)
+        self.deploy_namespace(namespace, [])
+        self.deploy_delayed_readiness_pod(delayed_1, namespace, 0, label)
+        self.deploy_delayed_readiness_pod(delayed_2, namespace, 0, label)
+
+        while not self.lib_k8s.is_pod_running(
+            delayed_1, namespace
+        ) and not self.lib_k8s.is_pod_running(delayed_2, namespace):
+            time.sleep(1)
+            continue
+        time.sleep(3)
+
+        monitor_timeout = 120
+        cancel_delay = 1
+
+        start_time = time.time()
+        future = select_and_monitor_by_name_pattern_and_namespace_pattern(
+            pod_name_pattern="^delayed-cancel-2-.*",
+            namespace_pattern=f"^{namespace_random_pattern}-.*",
+            max_timeout=monitor_timeout,
+            v1_client=self.lib_k8s.cli,
+        )
+
+        time.sleep(cancel_delay)
+        future.cancel()
+
+        # Wait for future to finish (may take up to 5 seconds)
+        max_wait_time = 10
+        wait_start = time.time()
+        while not future.done():
+            if time.time() - wait_start > max_wait_time:
+                self.fail("Future did not complete after cancellation")
+            time.sleep(0.1)
+
+        try:
+            snapshot = future.result(timeout=1)
+        except Exception as e:
+            self.fail(f"Future.result() raised exception: {e}")
+
+        end_time = time.time()
+        pods_status = snapshot.get_pods_status()
+
+        total_time = end_time - start_time
+        self.assertLess(
+            total_time, 8, "Cancellation should complete within 8 seconds"
+        )
+        self.assertIsNotNone(pods_status)
+
+        self.background_delete_pod(delayed_1, namespace)
+        self.background_delete_pod(delayed_2, namespace)
+        self.background_delete_ns(namespace)
+
+    def test_monitor_cancel_by_namespace_pattern_and_label(self):
+        # Test cancellation with namespace pattern and label monitoring
+        namespace = "test-ns-cancel-3-" + self.get_random_string(10)
+        delayed_1 = "delayed-cancel-3-" + self.get_random_string(10)
+        delayed_2 = "delayed-cancel-3-" + self.get_random_string(10)
+        label = "readiness-" + self.get_random_string(5)
+        self.deploy_namespace(namespace, [])
+        self.deploy_delayed_readiness_pod(delayed_1, namespace, 0, label)
+        self.deploy_delayed_readiness_pod(delayed_2, namespace, 0, label)
+
+        while not self.lib_k8s.is_pod_running(
+            delayed_1, namespace
+        ) and not self.lib_k8s.is_pod_running(delayed_2, namespace):
+            time.sleep(1)
+            continue
+        time.sleep(3)
+
+        monitor_timeout = 120
+        cancel_delay = 1
+
+        start_time = time.time()
+        future = select_and_monitor_by_namespace_pattern_and_label(
+            namespace_pattern="^test-ns-cancel-3-.*",
+            label_selector=f"test={label}",
+            max_timeout=monitor_timeout,
+            v1_client=self.lib_k8s.cli,
+        )
+
+        time.sleep(cancel_delay)
+        future.cancel()
+
+        # Wait for future to finish (may take up to 5 seconds)
+        max_wait_time = 10
+        wait_start = time.time()
+        while not future.done():
+            if time.time() - wait_start > max_wait_time:
+                self.fail("Future did not complete after cancellation")
+            time.sleep(0.1)
+
+        try:
+            snapshot = future.result(timeout=1)
+        except Exception as e:
+            self.fail(f"Future.result() raised exception: {e}")
+
+        end_time = time.time()
+        pods_status = snapshot.get_pods_status()
+
+        total_time = end_time - start_time
+        self.assertLess(
+            total_time, 8, "Cancellation should complete within 8 seconds"
+        )
+        self.assertIsNotNone(pods_status)
+
+        self.background_delete_pod(delayed_1, namespace)
+        self.background_delete_pod(delayed_2, namespace)
+        self.background_delete_ns(namespace)
+
+    def test_monitor_cancel_immediately(self):
+        # Test that cancel() works even if called immediately
+        namespace = "test-ns-cancel-4-" + self.get_random_string(10)
+        delayed_1 = "delayed-cancel-4-" + self.get_random_string(10)
+        delayed_2 = "delayed-cancel-4-" + self.get_random_string(10)
+        label = "readiness-" + self.get_random_string(5)
+        self.deploy_namespace(namespace, [])
+        self.deploy_delayed_readiness_pod(delayed_1, namespace, 0, label)
+        self.deploy_delayed_readiness_pod(delayed_2, namespace, 0, label)
+
+        while not self.lib_k8s.is_pod_running(
+            delayed_1, namespace
+        ) and not self.lib_k8s.is_pod_running(delayed_2, namespace):
+            time.sleep(1)
+            continue
+        time.sleep(3)
+
+        monitor_timeout = 120
+
+        start_time = time.time()
+        future = select_and_monitor_by_label(
+            label_selector=f"test={label}",
+            max_timeout=monitor_timeout,
+            v1_client=self.lib_k8s.cli,
+        )
+
+        # Cancel immediately
+        future.cancel()
+
+        # Wait for future to finish (may take up to 5 seconds)
+        max_wait_time = 10
+        wait_start = time.time()
+        while not future.done():
+            if time.time() - wait_start > max_wait_time:
+                self.fail("Future did not complete after cancellation")
+            time.sleep(0.1)
+
+        try:
+            snapshot = future.result(timeout=1)
+        except Exception as e:
+            self.fail(f"Future.result() raised exception: {e}")
+
+        end_time = time.time()
+        pods_status = snapshot.get_pods_status()
+
+        total_time = end_time - start_time
+        # Should complete within reasonable time (stream_timeout is 5 sec)
+        self.assertLess(
+            total_time,
+            7,
+            "Immediate cancellation should complete within 7 seconds",
+        )
+        self.assertIsNotNone(pods_status)
+
+        self.background_delete_pod(delayed_1, namespace)
+        self.background_delete_pod(delayed_2, namespace)
+        self.background_delete_ns(namespace)
+
+    def test_monitor_cancel_after_pod_deletion(self):
+        # Test cancellation after a pod has been deleted but before recovery
+        namespace = "test-ns-cancel-5-" + self.get_random_string(10)
+        delayed_1 = "delayed-cancel-5-" + self.get_random_string(10)
+        delayed_2 = "delayed-cancel-5-" + self.get_random_string(10)
+        label = "readiness-" + self.get_random_string(5)
+        self.deploy_namespace(namespace, [])
+        self.deploy_delayed_readiness_pod(delayed_1, namespace, 0, label)
+        self.deploy_delayed_readiness_pod(delayed_2, namespace, 0, label)
+
+        while not self.lib_k8s.is_pod_running(
+            delayed_1, namespace
+        ) and not self.lib_k8s.is_pod_running(delayed_2, namespace):
+            time.sleep(1)
+            continue
+        time.sleep(3)
+
+        monitor_timeout = 120
+
+        future = select_and_monitor_by_label(
+            label_selector=f"test={label}",
+            max_timeout=monitor_timeout,
+            v1_client=self.lib_k8s.cli,
+        )
+
+        # Delete a pod to trigger monitoring
+        self.background_delete_pod(delayed_1, namespace)
+        time.sleep(1)  # Wait for deletion event to be processed
+
+        # Cancel after deletion but before recovery
+        future.cancel()
+
+        # Wait for future to finish (may take up to 5 seconds)
+        max_wait_time = 10
+        wait_start = time.time()
+        while not future.done():
+            if time.time() - wait_start > max_wait_time:
+                self.fail("Future did not complete after cancellation")
+            time.sleep(0.1)
+
+        try:
+            snapshot = future.result(timeout=1)
+        except Exception as e:
+            self.fail(f"Future.result() raised exception: {e}")
+
+        pods_status = snapshot.get_pods_status()
+
+        # Should have captured the deletion event
+        self.assertIsNotNone(pods_status)
+        # The deleted pod might be in unrecovered or we might have partial
+        # data. This depends on timing, so we just verify we got a valid
+        # result
+
+        self.background_delete_pod(delayed_2, namespace)
+        self.background_delete_ns(namespace)


### PR DESCRIPTION
## Description  
Adding the ability to cancel _monitor_pods in the threads if an error comes up in the pod disruption scenario 

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  