### PR TITLE
add integration tests for KrknElastic with mock Elasticsearch client

### DIFF
--- a/src/krkn_lib/tests/test_krkn_elastic.py
+++ b/src/krkn_lib/tests/test_krkn_elastic.py
@@ -1,598 +1,302 @@
-import datetime
-import time
-import unittest
+import os
 import uuid
-from unittest.mock import Mock, MagicMock, patch
-
-from elasticsearch import NotFoundError
+from unittest.mock import MagicMock, patch
 
 from krkn_lib.elastic.krkn_elastic import KrknElastic
-from krkn_lib.models.elastic.models import ElasticAlert, ElasticMetric
+from krkn_lib.models.elastic.models import (
+    ElasticAlert,
+    ElasticMetric,
+)
 from krkn_lib.models.telemetry import ChaosRunTelemetry
-from krkn_lib.tests import BaseTest
-from krkn_lib.utils import SafeLogger
+from krkn_lib.utils.safe_logger import SafeLogger
+from krkn_lib.tests.base_test import BaseTest
 
-
-class TestKrknElasticWithMock(unittest.TestCase):
-    """Tests for KrknElastic using mocks (no Elasticsearch required)"""
-
+class TestKrknElastic(BaseTest):
     def setUp(self):
-        """Set up mock Elasticsearch client"""
-        self.mock_es = MagicMock()
-        self.safe_logger = SafeLogger()
+        self.safe_logger = MagicMock(spec=SafeLogger)
+        self.elastic_url = os.getenv("ELASTIC_URL", "http://localhost")
+        self.elastic_port = int(os.getenv("ELASTIC_PORT", 9200))
 
     @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_init_success(self, mock_elasticsearch):
-        """Test successful initialization"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(
-            self.safe_logger, "http://localhost", 9200, username="user", password="pass"
+    def test_init(self, mock_es):
+        krkn_elastic = KrknElastic(
+            self.safe_logger, self.elastic_url, self.elastic_port
         )
-        self.assertIsNotNone(elastic.es)
-        mock_elasticsearch.assert_called_once()
+        mock_es.assert_called_with(
+            f"{self.elastic_url}:{self.elastic_port}",
+            http_auth=None,
+            verify_certs=False,
+            ssl_show_warn=False,
+        )
+        self.assertIsNotNone(krkn_elastic.es)
 
     @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_init_no_credentials(self, mock_elasticsearch):
-        """Test initialization without credentials"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-        self.assertIsNotNone(elastic.es)
-
-    def test_init_no_url(self):
-        """Test initialization with empty URL raises exception"""
-        with self.assertRaises(Exception) as context:
-            KrknElastic(self.safe_logger, "", 9200)
-        self.assertIn("elastic search url is not valid", str(context.exception))
-
-    def test_init_no_port(self):
-        """Test initialization with no port raises exception"""
-        with self.assertRaises(Exception) as context:
-            KrknElastic(self.safe_logger, "http://localhost", None)
-        self.assertIn("elastic port is not valid", str(context.exception))
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_upload_data_success(self, mock_elasticsearch):
-        """Test successful data upload"""
-        mock_elasticsearch.return_value = self.mock_es
-        self.mock_es.index.return_value = {"result": "created"}
-
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-        result = elastic.upload_data_to_elasticsearch(
-            {"test": "data"}, "test-index"
+    def test_init_with_auth(self, mock_es):
+        username = "user"
+        password = "password"
+        krkn_elastic = KrknElastic(
+            self.safe_logger,
+            self.elastic_url,
+            self.elastic_port,
+            username=username,
+            password=password,
+        )
+        mock_es.assert_called_with(
+            f"{self.elastic_url}:{self.elastic_port}",
+            http_auth=(username, password),
+            verify_certs=False,
+            ssl_show_warn=False,
         )
 
+    def test_init_invalid_params(self):
+        with self.assertRaises(Exception):
+            KrknElastic(self.safe_logger, "")
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_upload_data_to_elasticsearch(self, mock_es):
+        mock_es_instance = MagicMock()
+        mock_es.return_value = mock_es_instance
+        mock_es_instance.index.return_value = {"result": "created"}
+
+        krkn_elastic = KrknElastic(
+            self.safe_logger, self.elastic_url, self.elastic_port
+        )
+        item = {"key": "value"}
+        index = "test-index"
+
+        result = krkn_elastic.upload_data_to_elasticsearch(item, index)
+        mock_es_instance.index.assert_called_with(index=index, body=item)
         self.assertGreaterEqual(result, 0)
-        self.mock_es.index.assert_called_once()
 
     @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_upload_data_empty_index(self, mock_elasticsearch):
-        """Test upload with empty index returns 0"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+    def test_upload_data_to_elasticsearch_fail(self, mock_es):
+        mock_es_instance = MagicMock()
+        mock_es.return_value = mock_es_instance
+        mock_es_instance.index.return_value = {"result": "error"}
 
-        result = elastic.upload_data_to_elasticsearch({"test": "data"}, "")
-        self.assertEqual(result, 0)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_upload_data_failed(self, mock_elasticsearch):
-        """Test failed data upload"""
-        mock_elasticsearch.return_value = self.mock_es
-        self.mock_es.index.return_value = {"result": "failed"}
-
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-        result = elastic.upload_data_to_elasticsearch(
-            {"test": "data"}, "test-index"
+        krkn_elastic = KrknElastic(
+            self.safe_logger, self.elastic_url, self.elastic_port
         )
+        item = {"key": "value"}
+        index = "test-index"
 
+        result = krkn_elastic.upload_data_to_elasticsearch(item, index)
         self.assertEqual(result, -1)
 
     @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_upload_data_exception(self, mock_elasticsearch):
-        """Test data upload with exception"""
-        mock_elasticsearch.return_value = self.mock_es
-        self.mock_es.index.side_effect = Exception("Connection error")
-
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-        result = elastic.upload_data_to_elasticsearch(
-            {"test": "data"}, "test-index"
-        )
-
-        self.assertEqual(result, -1)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_push_metric_success(self, mock_elasticsearch):
-        """Test successful metric push"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        metric = ElasticMetric(
-            run_uuid="test-uuid",
-            name="test-metric",
-            timestamp=datetime.datetime.now(),
-            value=1.0,
-        )
-
-        result = elastic.push_metric(metric, "test-index")
-        self.assertGreaterEqual(result, 0)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_push_metric_no_index(self, mock_elasticsearch):
-        """Test push metric with no index raises exception"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        metric = ElasticMetric(
-            run_uuid="test-uuid",
-            name="test-metric",
-            timestamp=datetime.datetime.now(),
-            value=1.0,
-        )
-
-        with self.assertRaises(Exception) as context:
-            elastic.push_metric(metric, "")
-        self.assertIn("index cannot be None or empty", str(context.exception))
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_push_metric_exception(self, mock_elasticsearch):
-        """Test push metric with exception"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        metric = ElasticMetric(
-            run_uuid="test-uuid",
-            name="test-metric",
-            timestamp=datetime.datetime.now(),
-            value=1.0,
-        )
-
-        # Mock save to raise exception
-        metric.save = Mock(side_effect=Exception("Save failed"))
-
-        result = elastic.push_metric(metric, "test-index")
-        self.assertEqual(result, -1)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_push_alert_success(self, mock_elasticsearch):
-        """Test successful alert push"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        alert = ElasticAlert(
-            run_uuid="test-uuid",
-            alert="test-alert",
-            severity="WARNING",
-            created_at=datetime.datetime.now(),
-        )
-
-        result = elastic.push_alert(alert, "test-index")
-        self.assertGreaterEqual(result, 0)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_push_alert_no_index(self, mock_elasticsearch):
-        """Test push alert with no index raises exception"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        alert = ElasticAlert(
-            run_uuid="test-uuid",
-            alert="test-alert",
-            severity="WARNING",
-            created_at=datetime.datetime.now(),
-        )
-
-        with self.assertRaises(Exception) as context:
-            elastic.push_alert(alert, "")
-        self.assertIn("index cannot be None or empty", str(context.exception))
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_push_alert_exception(self, mock_elasticsearch):
-        """Test push alert with exception"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        alert = ElasticAlert(
-            run_uuid="test-uuid",
-            alert="test-alert",
-            severity="WARNING",
-            created_at=datetime.datetime.now(),
-        )
-
-        # Mock save to raise exception
-        alert.save = Mock(side_effect=Exception("Save failed"))
-
-        result = elastic.push_alert(alert, "test-index")
-        self.assertEqual(result, -1)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_push_telemetry_success(self, mock_elasticsearch):
-        """Test successful telemetry push"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        # Create minimal telemetry with all required fields
-        telemetry_data = {
-            "run_uuid": "test-uuid",
-            "scenarios": [],
-            "timestamp": "2023-05-22T14:55:02Z",
-            "job_status": True,
-            "node_summary_infos": [],
-            "node_taints": [],
-            "kubernetes_objects_count": {},
-            "network_plugins": [],
-        }
-        telemetry = ChaosRunTelemetry(json_dict=telemetry_data)
-
-        result = elastic.push_telemetry(telemetry, "test-index")
-        self.assertGreaterEqual(result, 0)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_push_telemetry_no_index(self, mock_elasticsearch):
-        """Test push telemetry with no index raises exception"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        telemetry_data = {
-            "run_uuid": "test-uuid",
-            "scenarios": [],
-            "timestamp": "2023-05-22T14:55:02Z",
-            "job_status": True,
-            "node_summary_infos": [],
-            "node_taints": [],
-            "kubernetes_objects_count": {},
-            "network_plugins": [],
-        }
-        telemetry = ChaosRunTelemetry(json_dict=telemetry_data)
-
-        with self.assertRaises(Exception) as context:
-            elastic.push_telemetry(telemetry, "")
-        self.assertIn("index cannot be None or empty", str(context.exception))
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_upload_metrics_to_elasticsearch_success(self, mock_elasticsearch):
-        """Test successful metrics upload"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        raw_data = [
-            {
-                "name": "test-metric",
-                "timestamp": datetime.datetime.now(),
-                "value": 3.14,
-            }
-        ]
-
-        result = elastic.upload_metrics_to_elasticsearch(
-            "test-uuid", raw_data, "test-index"
-        )
-        self.assertGreaterEqual(result, 0)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_upload_metrics_no_index(self, mock_elasticsearch):
-        """Test upload metrics with no index raises exception"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        with self.assertRaises(Exception) as context:
-            elastic.upload_metrics_to_elasticsearch("test-uuid", [], "")
-        self.assertIn("index cannot be None or empty", str(context.exception))
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_upload_metrics_no_uuid(self, mock_elasticsearch):
-        """Test upload metrics with no UUID raises exception"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        with self.assertRaises(Exception) as context:
-            elastic.upload_metrics_to_elasticsearch("", [], "test-index")
-        self.assertIn("run uuid cannot be None or empty", str(context.exception))
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    @patch("krkn_lib.elastic.krkn_elastic.Search")
-    def test_search_alert_success(self, mock_search_class, mock_elasticsearch):
-        """Test successful alert search"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        # Mock search results
-        mock_hit = Mock()
-        mock_hit.to_dict.return_value = {
-            "run_uuid": "test-uuid",
-            "alert": "test-alert",
-            "severity": "WARNING",
-            "created_at": datetime.datetime.now(),
-        }
-
-        mock_result = Mock()
-        mock_result.__iter__ = Mock(return_value=iter([mock_hit]))
-
-        mock_search = Mock()
-        mock_search.filter.return_value = mock_search
-        mock_search.execute.return_value = mock_result
-        mock_search_class.return_value = mock_search
-
-        results = elastic.search_alert("test-uuid", "test-index")
-        self.assertEqual(len(results), 1)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    @patch("krkn_lib.elastic.krkn_elastic.Search")
-    def test_search_alert_not_found(self, mock_search_class, mock_elasticsearch):
-        """Test alert search when index not found"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        mock_search = Mock()
-        mock_search.filter.return_value = mock_search
-        mock_search.execute.side_effect = NotFoundError("Index not found")
-        mock_search_class.return_value = mock_search
-
-        results = elastic.search_alert("test-uuid", "test-index")
-        self.assertEqual(len(results), 0)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    @patch("krkn_lib.elastic.krkn_elastic.Search")
-    def test_search_metric_success(self, mock_search_class, mock_elasticsearch):
-        """Test successful metric search"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        # Mock search results
-        mock_hit = Mock()
-        mock_hit.to_dict.return_value = {
-            "run_uuid": "test-uuid",
-            "name": "test-metric",
-            "timestamp": datetime.datetime.now(),
-            "value": 1.0,
-        }
-
-        mock_result = Mock()
-        mock_result.__iter__ = Mock(return_value=iter([mock_hit]))
-
-        mock_search = Mock()
-        mock_search.filter.return_value = mock_search
-        mock_search.execute.return_value = mock_result
-        mock_search_class.return_value = mock_search
-
-        results = elastic.search_metric("test-uuid", "test-index")
-        self.assertEqual(len(results), 1)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    @patch("krkn_lib.elastic.krkn_elastic.Search")
-    def test_search_metric_not_found(self, mock_search_class, mock_elasticsearch):
-        """Test metric search when index not found"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        mock_search = Mock()
-        mock_search.filter.return_value = mock_search
-        mock_search.execute.side_effect = NotFoundError("Index not found")
-        mock_search_class.return_value = mock_search
-
-        results = elastic.search_metric("test-uuid", "test-index")
-        self.assertEqual(len(results), 0)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    @patch("krkn_lib.elastic.krkn_elastic.Search")
-    def test_search_telemetry_success(self, mock_search_class, mock_elasticsearch):
-        """Test successful telemetry search"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        # Mock search results
-        mock_hit = Mock()
-        mock_hit.to_dict.return_value = {
-            "run_uuid": "test-uuid",
-            "scenarios": [],
-            "timestamp": "2023-05-22T14:55:02Z",
-            "job_status": True,
-            "node_summary_infos": [],
-            "node_taints": [],
-            "kubernetes_objects_count": {},
-            "network_plugins": [],
-        }
-
-        mock_result = Mock()
-        mock_result.__iter__ = Mock(return_value=iter([mock_hit]))
-
-        mock_search = Mock()
-        mock_search.filter.return_value = mock_search
-        mock_search.execute.return_value = mock_result
-        mock_search_class.return_value = mock_search
-
-        results = elastic.search_telemetry("test-uuid", "test-index")
-        self.assertEqual(len(results), 1)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    @patch("krkn_lib.elastic.krkn_elastic.Search")
-    def test_search_telemetry_not_found(
-        self, mock_search_class, mock_elasticsearch
-    ):
-        """Test telemetry search when index not found"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        mock_search = Mock()
-        mock_search.filter.return_value = mock_search
-        mock_search.execute.side_effect = NotFoundError("Index not found")
-        mock_search_class.return_value = mock_search
-
-        results = elastic.search_telemetry("test-uuid", "test-index")
-        self.assertEqual(len(results), 0)
-
-    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_upload_metrics_exception(self, mock_elasticsearch):
-        """Test upload metrics with exception during push"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
-
-        # Mock push_metric to return error
-        with patch.object(elastic, 'push_metric', return_value=-1):
-            raw_data = [
-                {
-                    "name": "test-metric",
-                    "timestamp": datetime.datetime.now(),
-                    "value": 3.14,
-                }
-            ]
-            result = elastic.upload_metrics_to_elasticsearch(
-                "test-uuid", raw_data, "test-index"
+    def test_upload_metrics_to_elasticsearch(self, mock_es):
+        mock_es_instance = MagicMock()
+        mock_es.return_value = mock_es_instance
+        
+        # Mock the save method on ElasticMetric instance
+        with patch("krkn_lib.models.elastic.models.ElasticMetric.save") as mock_save:
+            krkn_elastic = KrknElastic(
+                self.safe_logger, self.elastic_url, self.elastic_port
             )
-            # Should still complete but log errors
+            run_uuid = "test-uuid"
+            raw_data = [{"name": "metric1", "value": 10}]
+            index = "test-index"
+
+            result = krkn_elastic.upload_metrics_to_elasticsearch(
+                run_uuid, raw_data, index
+            )
+            
+            self.assertEqual(mock_save.call_count, 1)
             self.assertGreaterEqual(result, 0)
 
     @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_upload_metrics_invalid_data(self, mock_elasticsearch):
-        """Test upload metrics with invalid metric data that raises exception"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+    def test_push_alert(self, mock_es):
+        mock_es_instance = MagicMock()
+        mock_es.return_value = mock_es_instance
+        
+        krkn_elastic = KrknElastic(
+            self.safe_logger, self.elastic_url, self.elastic_port
+        )
+        alert = MagicMock(spec=ElasticAlert)
+        index = "test-index"
 
-        # Mock ElasticMetric to raise exception
-        raw_data = [
-            {
-                "name": "test-metric",
-                "timestamp": datetime.datetime.now(),
-                "value": 3.14,
-            }
-        ]
-
-        with patch('krkn_lib.elastic.krkn_elastic.ElasticMetric', side_effect=Exception("Invalid data")):
-            result = elastic.upload_metrics_to_elasticsearch(
-                "test-uuid", raw_data, "test-index"
-            )
-            # Should return -1 on exception
-            self.assertEqual(result, -1)
+        result = krkn_elastic.push_alert(alert, index)
+        alert.save.assert_called_with(using=mock_es_instance, index=index)
+        self.assertGreaterEqual(result, 0)
 
     @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
-    def test_push_telemetry_exception(self, mock_elasticsearch):
-        """Test push telemetry with exception"""
-        mock_elasticsearch.return_value = self.mock_es
-        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+    def test_push_metric(self, mock_es):
+        mock_es_instance = MagicMock()
+        mock_es.return_value = mock_es_instance
+        
+        krkn_elastic = KrknElastic(
+            self.safe_logger, self.elastic_url, self.elastic_port
+        )
+        metric = MagicMock(spec=ElasticMetric)
+        index = "test-index"
 
-        telemetry_data = {
-            "run_uuid": "test-uuid",
-            "scenarios": [],
-            "timestamp": "2023-05-22T14:55:02Z",
-            "job_status": True,
-            "node_summary_infos": [],
-            "node_taints": [],
-            "kubernetes_objects_count": {},
-            "network_plugins": [],
-        }
-        telemetry = ChaosRunTelemetry(json_dict=telemetry_data)
+        result = krkn_elastic.push_metric(metric, index)
+        metric.save.assert_called_with(using=mock_es_instance, index=index)
+        self.assertGreaterEqual(result, 0)
 
-        # Mock to raise exception during save
-        with patch('krkn_lib.models.elastic.models.ElasticChaosRunTelemetry.save', side_effect=Exception("Save failed")):
-            result = elastic.push_telemetry(telemetry, "test-index")
-            self.assertEqual(result, -1)
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_push_telemetry(self, mock_es):
+        mock_es_instance = MagicMock()
+        mock_es.return_value = mock_es_instance
+        
+        krkn_elastic = KrknElastic(
+            self.safe_logger, self.elastic_url, self.elastic_port
+        )
+        telemetry = MagicMock(spec=ChaosRunTelemetry)
+        # Mock attributes needed for ElasticChaosRunTelemetry constructor
+        telemetry.scenarios = []
+        telemetry.node_summary_infos = []
+        telemetry.node_taints = []
+        telemetry.kubernetes_objects_count = {}
+        telemetry.network_plugins = []
+        telemetry.health_checks = []
+        telemetry.virt_checks = []
+        telemetry.post_virt_checks = []
+        
+        index = "test-index"
+
+        with patch("krkn_lib.elastic.krkn_elastic.ElasticChaosRunTelemetry") as mock_elastic_telemetry_cls:
+            mock_elastic_telemetry = MagicMock()
+            mock_elastic_telemetry_cls.return_value = mock_elastic_telemetry
+            
+            result = krkn_elastic.push_telemetry(telemetry, index)
+            
+            mock_elastic_telemetry.save.assert_called_with(using=mock_es_instance, index=index)
+            self.assertGreaterEqual(result, 0)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Search")
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_search_telemetry(self, mock_es, mock_search):
+        mock_es_instance = MagicMock()
+        mock_es.return_value = mock_es_instance
+        
+        mock_search_instance = MagicMock()
+        mock_search.return_value = mock_search_instance
+        mock_search_instance.filter.return_value = mock_search_instance
+        
+        mock_hit = MagicMock()
+        mock_hit.to_dict.return_value = {}
+        mock_search_instance.execute.return_value = [mock_hit]
+
+        krkn_elastic = KrknElastic(
+            self.safe_logger, self.elastic_url, self.elastic_port
+        )
+        run_uuid = "test-uuid"
+        index = "test-index"
+
+        with patch("krkn_lib.elastic.krkn_elastic.ElasticChaosRunTelemetry") as mock_cls:
+            results = krkn_elastic.search_telemetry(run_uuid, index)
+            
+            mock_search.assert_called_with(using=mock_es_instance, index=index)
+            mock_search_instance.filter.assert_called_with("match", run_uuid=run_uuid)
+            self.assertEqual(len(results), 1)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Search")
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_search_alert(self, mock_es, mock_search):
+        mock_es_instance = MagicMock()
+        mock_es.return_value = mock_es_instance
+        
+        mock_search_instance = MagicMock()
+        mock_search.return_value = mock_search_instance
+        mock_search_instance.filter.return_value = mock_search_instance
+        
+        mock_hit = MagicMock()
+        mock_hit.to_dict.return_value = {}
+        mock_search_instance.execute.return_value = [mock_hit]
+
+        krkn_elastic = KrknElastic(
+            self.safe_logger, self.elastic_url, self.elastic_port
+        )
+        run_uuid = "test-uuid"
+        index = "test-index"
+
+        with patch("krkn_lib.elastic.krkn_elastic.ElasticAlert") as mock_cls:
+            results = krkn_elastic.search_alert(run_uuid, index)
+            
+            mock_search.assert_called_with(using=mock_es_instance, index=index)
+            self.assertEqual(len(results), 1)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Search")
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_search_metric(self, mock_es, mock_search):
+        mock_es_instance = MagicMock()
+        mock_es.return_value = mock_es_instance
+        
+        mock_search_instance = MagicMock()
+        mock_search.return_value = mock_search_instance
+        mock_search_instance.filter.return_value = mock_search_instance
+        
+        mock_hit = MagicMock()
+        mock_hit.to_dict.return_value = {}
+        mock_search_instance.execute.return_value = [mock_hit]
+
+        krkn_elastic = KrknElastic(
+            self.safe_logger, self.elastic_url, self.elastic_port
+        )
+        run_uuid = "test-uuid"
+        index = "test-index"
+
+        with patch("krkn_lib.elastic.krkn_elastic.ElasticMetric") as mock_cls:
+            results = krkn_elastic.search_metric(run_uuid, index)
+            
+            mock_search.assert_called_with(using=mock_es_instance, index=index)
+            self.assertEqual(len(results), 1)
 
 
 class TestKrknElasticIntegration(BaseTest):
-    """Integration tests that require actual Elasticsearch (original tests)"""
-
     def setUp(self):
-        """Skip tests if Elasticsearch is not configured"""
-        if self.lib_elastic is None:
-            self.skipTest("Elasticsearch not configured")
+        if not self.lib_elastic.es.ping():
+            self.skipTest("Elasticsearch is not reachable")
 
-    def test_push_search_alert(self):
+    def test_integration_upload_data(self):
+        item = {"key": "integration-test-value"}
+        index = "krkn-integration-test"
+
+        result = self.lib_elastic.upload_data_to_elasticsearch(item, index)
+        self.assertGreaterEqual(result, 0)
+
+    def test_integration_metrics_lifecycle(self):
+        """
+        Tests uploading metrics and then searching for them to verify persistence.
+        """
         run_uuid = str(uuid.uuid4())
-        index = "test-push-alert"
-        alert_1 = ElasticAlert(
-            alert="alert_1",
-            severity="WARNING",
-            created_at=datetime.datetime.now(),
-            run_uuid=run_uuid,
-        )
-        alert_2 = ElasticAlert(
-            alert="alert_2",
-            severity="ERROR",
-            created_at=datetime.datetime.now(),
-            run_uuid=run_uuid,
-        )
-        result = self.lib_elastic.push_alert(alert_1, index)
-        self.assertNotEqual(result, -1)
-        result = self.lib_elastic.push_alert(alert_2, index)
-        self.assertNotEqual(result, -1)
-        time.sleep(1)
-        alerts = self.lib_elastic.search_alert(run_uuid, index)
-        self.assertEqual(len(alerts), 2)
+        index = "krkn-integration-metrics"
+        raw_data = [{"name": "test_metric", "value": 99.9}]
 
-        alert = next(alert for alert in alerts if alert.alert == "alert_1")
-        self.assertIsNotNone(alert)
-        self.assertEqual(alert.severity, "WARNING")
-
-        alert = next(alert for alert in alerts if alert.alert == "alert_2")
-        self.assertIsNotNone(alert)
-        self.assertEqual(alert.severity, "ERROR")
-
-    def test_push_search_metric(self):
-        run_uuid = str(uuid.uuid4())
-        index = "test-push-metric"
-        timestamp = datetime.datetime.now()
-        metric_1 = ElasticMetric(
-            run_uuid=run_uuid,
-            metricName="metric_1",
-            timestamp=timestamp,
-            value=1.0,
+        # 1. Upload Metric
+        result = self.lib_elastic.upload_metrics_to_elasticsearch(
+            run_uuid, raw_data, index
         )
-        result = self.lib_elastic.push_metric(metric_1, index)
-        self.assertNotEqual(result, -1)
-        time.sleep(1)
+        self.assertGreaterEqual(result, 0)
+
+        # 2. Refresh index to make document immediately searchable
+        self.lib_elastic.es.indices.refresh(index=index)
+
+        # 3. Search and Verify
         metrics = self.lib_elastic.search_metric(run_uuid, index)
-        self.assertEqual(len(metrics), 1)
-        metric = metrics[0]
+        self.assertTrue(len(metrics) > 0, "Should find at least one metric")
+        self.assertEqual(metrics[0].run_uuid, run_uuid)
 
-        self.assertIsNotNone(metric)
-        self.assertEqual(
-            metric.timestamp, timestamp.strftime("%Y-%m-%dT%H:%M:%S.%f")
-        )
-        self.assertEqual(metric.run_uuid, run_uuid)
-        self.assertEqual(metric["value"], 1.0)
-
-    def test_push_search_telemetry(self):
+    def test_integration_alert_lifecycle(self):
+        """
+        Tests pushing an alert and searching for it.
+        """
         run_uuid = str(uuid.uuid4())
-        index = "test-push-telemetry"
-        example_data = self.get_ChaosRunTelemetry_json(run_uuid)
-        telemetry = ChaosRunTelemetry(json_dict=example_data)
-        res = self.lib_elastic.push_telemetry(telemetry, index)
-        self.assertNotEqual(res, -1)
-        time.sleep(3)
-        result = self.lib_elastic.search_telemetry(
-            run_uuid=run_uuid, index=index
+        index = "krkn-integration-alerts"
+        alert = ElasticAlert(
+            run_uuid=run_uuid, severity="critical", alert="Integration Test Alert"
         )
 
-        self.assertEqual(len(result), 1)
+        # 1. Push Alert
+        result = self.lib_elastic.push_alert(alert, index)
+        self.assertGreaterEqual(result, 0)
 
-    def test_upload_metric_to_elasticsearch(self):
-        bad_metric_uuid = str(uuid.uuid4())
-        good_metric_uuid = str(uuid.uuid4())
-        name = f"metric-{self.get_random_string(5)}"
-        index = "test-upload-metric"
-        # testing bad metric
-        self.lib_elastic.upload_metrics_to_elasticsearch(
-            run_uuid=bad_metric_uuid,
-            raw_data={
-                "name": 1,
-                "timestamp": "bad",
-                "value": "bad",
-            },
-            index=index,
-        )
+        # 2. Refresh index
+        self.lib_elastic.es.indices.refresh(index=index)
 
-        self.assertEqual(
-            len(self.lib_elastic.search_metric(bad_metric_uuid, index)), 0
-        )
-
-        time_now = datetime.datetime.now()
-        self.lib_elastic.upload_metrics_to_elasticsearch(
-            run_uuid=good_metric_uuid,
-            raw_data=[{"name": name, "timestamp": time_now, "value": 3.14}],
-            index=index,
-        )
-        time.sleep(1)
-        metric = self.lib_elastic.search_metric(good_metric_uuid, index)
-        self.assertEqual(len(metric), 1)
-        self.assertEqual(metric[0].name, name)
-        self.assertEqual(
-            metric[0].timestamp, time_now.strftime("%Y-%m-%dT%H:%M:%S.%f")
-        )
-        self.assertEqual(metric[0].value, 3.14)
+        # 3. Search and Verify
+        alerts = self.lib_elastic.search_alert(run_uuid, index)
+        self.assertTrue(len(alerts) > 0, "Should find at least one alert")
+        self.assertEqual(alerts[0].run_uuid, run_uuid)
+        self.assertEqual(alerts[0].alert, "Integration Test Alert")

--- a/src/krkn_lib/tests/test_krkn_elastic.py
+++ b/src/krkn_lib/tests/test_krkn_elastic.py
@@ -1,6 +1,10 @@
 import datetime
 import time
+import unittest
 import uuid
+from unittest.mock import Mock, MagicMock, patch
+
+from elasticsearch import NotFoundError
 
 from krkn_lib.elastic.krkn_elastic import KrknElastic
 from krkn_lib.models.elastic.models import ElasticAlert, ElasticMetric
@@ -9,7 +13,485 @@ from krkn_lib.tests import BaseTest
 from krkn_lib.utils import SafeLogger
 
 
-class TestKrknElastic(BaseTest):
+class TestKrknElasticWithMock(unittest.TestCase):
+    """Tests for KrknElastic using mocks (no Elasticsearch required)"""
+
+    def setUp(self):
+        """Set up mock Elasticsearch client"""
+        self.mock_es = MagicMock()
+        self.safe_logger = SafeLogger()
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_init_success(self, mock_elasticsearch):
+        """Test successful initialization"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(
+            self.safe_logger, "http://localhost", 9200, username="user", password="pass"
+        )
+        self.assertIsNotNone(elastic.es)
+        mock_elasticsearch.assert_called_once()
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_init_no_credentials(self, mock_elasticsearch):
+        """Test initialization without credentials"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+        self.assertIsNotNone(elastic.es)
+
+    def test_init_no_url(self):
+        """Test initialization with empty URL raises exception"""
+        with self.assertRaises(Exception) as context:
+            KrknElastic(self.safe_logger, "", 9200)
+        self.assertIn("elastic search url is not valid", str(context.exception))
+
+    def test_init_no_port(self):
+        """Test initialization with no port raises exception"""
+        with self.assertRaises(Exception) as context:
+            KrknElastic(self.safe_logger, "http://localhost", None)
+        self.assertIn("elastic port is not valid", str(context.exception))
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_upload_data_success(self, mock_elasticsearch):
+        """Test successful data upload"""
+        mock_elasticsearch.return_value = self.mock_es
+        self.mock_es.index.return_value = {"result": "created"}
+
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+        result = elastic.upload_data_to_elasticsearch(
+            {"test": "data"}, "test-index"
+        )
+
+        self.assertGreaterEqual(result, 0)
+        self.mock_es.index.assert_called_once()
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_upload_data_empty_index(self, mock_elasticsearch):
+        """Test upload with empty index returns 0"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        result = elastic.upload_data_to_elasticsearch({"test": "data"}, "")
+        self.assertEqual(result, 0)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_upload_data_failed(self, mock_elasticsearch):
+        """Test failed data upload"""
+        mock_elasticsearch.return_value = self.mock_es
+        self.mock_es.index.return_value = {"result": "failed"}
+
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+        result = elastic.upload_data_to_elasticsearch(
+            {"test": "data"}, "test-index"
+        )
+
+        self.assertEqual(result, -1)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_upload_data_exception(self, mock_elasticsearch):
+        """Test data upload with exception"""
+        mock_elasticsearch.return_value = self.mock_es
+        self.mock_es.index.side_effect = Exception("Connection error")
+
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+        result = elastic.upload_data_to_elasticsearch(
+            {"test": "data"}, "test-index"
+        )
+
+        self.assertEqual(result, -1)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_push_metric_success(self, mock_elasticsearch):
+        """Test successful metric push"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        metric = ElasticMetric(
+            run_uuid="test-uuid",
+            name="test-metric",
+            timestamp=datetime.datetime.now(),
+            value=1.0,
+        )
+
+        result = elastic.push_metric(metric, "test-index")
+        self.assertGreaterEqual(result, 0)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_push_metric_no_index(self, mock_elasticsearch):
+        """Test push metric with no index raises exception"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        metric = ElasticMetric(
+            run_uuid="test-uuid",
+            name="test-metric",
+            timestamp=datetime.datetime.now(),
+            value=1.0,
+        )
+
+        with self.assertRaises(Exception) as context:
+            elastic.push_metric(metric, "")
+        self.assertIn("index cannot be None or empty", str(context.exception))
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_push_metric_exception(self, mock_elasticsearch):
+        """Test push metric with exception"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        metric = ElasticMetric(
+            run_uuid="test-uuid",
+            name="test-metric",
+            timestamp=datetime.datetime.now(),
+            value=1.0,
+        )
+
+        # Mock save to raise exception
+        metric.save = Mock(side_effect=Exception("Save failed"))
+
+        result = elastic.push_metric(metric, "test-index")
+        self.assertEqual(result, -1)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_push_alert_success(self, mock_elasticsearch):
+        """Test successful alert push"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        alert = ElasticAlert(
+            run_uuid="test-uuid",
+            alert="test-alert",
+            severity="WARNING",
+            created_at=datetime.datetime.now(),
+        )
+
+        result = elastic.push_alert(alert, "test-index")
+        self.assertGreaterEqual(result, 0)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_push_alert_no_index(self, mock_elasticsearch):
+        """Test push alert with no index raises exception"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        alert = ElasticAlert(
+            run_uuid="test-uuid",
+            alert="test-alert",
+            severity="WARNING",
+            created_at=datetime.datetime.now(),
+        )
+
+        with self.assertRaises(Exception) as context:
+            elastic.push_alert(alert, "")
+        self.assertIn("index cannot be None or empty", str(context.exception))
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_push_alert_exception(self, mock_elasticsearch):
+        """Test push alert with exception"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        alert = ElasticAlert(
+            run_uuid="test-uuid",
+            alert="test-alert",
+            severity="WARNING",
+            created_at=datetime.datetime.now(),
+        )
+
+        # Mock save to raise exception
+        alert.save = Mock(side_effect=Exception("Save failed"))
+
+        result = elastic.push_alert(alert, "test-index")
+        self.assertEqual(result, -1)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_push_telemetry_success(self, mock_elasticsearch):
+        """Test successful telemetry push"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        # Create minimal telemetry with all required fields
+        telemetry_data = {
+            "run_uuid": "test-uuid",
+            "scenarios": [],
+            "timestamp": "2023-05-22T14:55:02Z",
+            "job_status": True,
+            "node_summary_infos": [],
+            "node_taints": [],
+            "kubernetes_objects_count": {},
+            "network_plugins": [],
+        }
+        telemetry = ChaosRunTelemetry(json_dict=telemetry_data)
+
+        result = elastic.push_telemetry(telemetry, "test-index")
+        self.assertGreaterEqual(result, 0)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_push_telemetry_no_index(self, mock_elasticsearch):
+        """Test push telemetry with no index raises exception"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        telemetry_data = {
+            "run_uuid": "test-uuid",
+            "scenarios": [],
+            "timestamp": "2023-05-22T14:55:02Z",
+            "job_status": True,
+            "node_summary_infos": [],
+            "node_taints": [],
+            "kubernetes_objects_count": {},
+            "network_plugins": [],
+        }
+        telemetry = ChaosRunTelemetry(json_dict=telemetry_data)
+
+        with self.assertRaises(Exception) as context:
+            elastic.push_telemetry(telemetry, "")
+        self.assertIn("index cannot be None or empty", str(context.exception))
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_upload_metrics_to_elasticsearch_success(self, mock_elasticsearch):
+        """Test successful metrics upload"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        raw_data = [
+            {
+                "name": "test-metric",
+                "timestamp": datetime.datetime.now(),
+                "value": 3.14,
+            }
+        ]
+
+        result = elastic.upload_metrics_to_elasticsearch(
+            "test-uuid", raw_data, "test-index"
+        )
+        self.assertGreaterEqual(result, 0)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_upload_metrics_no_index(self, mock_elasticsearch):
+        """Test upload metrics with no index raises exception"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        with self.assertRaises(Exception) as context:
+            elastic.upload_metrics_to_elasticsearch("test-uuid", [], "")
+        self.assertIn("index cannot be None or empty", str(context.exception))
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_upload_metrics_no_uuid(self, mock_elasticsearch):
+        """Test upload metrics with no UUID raises exception"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        with self.assertRaises(Exception) as context:
+            elastic.upload_metrics_to_elasticsearch("", [], "test-index")
+        self.assertIn("run uuid cannot be None or empty", str(context.exception))
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    @patch("krkn_lib.elastic.krkn_elastic.Search")
+    def test_search_alert_success(self, mock_search_class, mock_elasticsearch):
+        """Test successful alert search"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        # Mock search results
+        mock_hit = Mock()
+        mock_hit.to_dict.return_value = {
+            "run_uuid": "test-uuid",
+            "alert": "test-alert",
+            "severity": "WARNING",
+            "created_at": datetime.datetime.now(),
+        }
+
+        mock_result = Mock()
+        mock_result.__iter__ = Mock(return_value=iter([mock_hit]))
+
+        mock_search = Mock()
+        mock_search.filter.return_value = mock_search
+        mock_search.execute.return_value = mock_result
+        mock_search_class.return_value = mock_search
+
+        results = elastic.search_alert("test-uuid", "test-index")
+        self.assertEqual(len(results), 1)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    @patch("krkn_lib.elastic.krkn_elastic.Search")
+    def test_search_alert_not_found(self, mock_search_class, mock_elasticsearch):
+        """Test alert search when index not found"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        mock_search = Mock()
+        mock_search.filter.return_value = mock_search
+        mock_search.execute.side_effect = NotFoundError("Index not found")
+        mock_search_class.return_value = mock_search
+
+        results = elastic.search_alert("test-uuid", "test-index")
+        self.assertEqual(len(results), 0)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    @patch("krkn_lib.elastic.krkn_elastic.Search")
+    def test_search_metric_success(self, mock_search_class, mock_elasticsearch):
+        """Test successful metric search"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        # Mock search results
+        mock_hit = Mock()
+        mock_hit.to_dict.return_value = {
+            "run_uuid": "test-uuid",
+            "name": "test-metric",
+            "timestamp": datetime.datetime.now(),
+            "value": 1.0,
+        }
+
+        mock_result = Mock()
+        mock_result.__iter__ = Mock(return_value=iter([mock_hit]))
+
+        mock_search = Mock()
+        mock_search.filter.return_value = mock_search
+        mock_search.execute.return_value = mock_result
+        mock_search_class.return_value = mock_search
+
+        results = elastic.search_metric("test-uuid", "test-index")
+        self.assertEqual(len(results), 1)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    @patch("krkn_lib.elastic.krkn_elastic.Search")
+    def test_search_metric_not_found(self, mock_search_class, mock_elasticsearch):
+        """Test metric search when index not found"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        mock_search = Mock()
+        mock_search.filter.return_value = mock_search
+        mock_search.execute.side_effect = NotFoundError("Index not found")
+        mock_search_class.return_value = mock_search
+
+        results = elastic.search_metric("test-uuid", "test-index")
+        self.assertEqual(len(results), 0)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    @patch("krkn_lib.elastic.krkn_elastic.Search")
+    def test_search_telemetry_success(self, mock_search_class, mock_elasticsearch):
+        """Test successful telemetry search"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        # Mock search results
+        mock_hit = Mock()
+        mock_hit.to_dict.return_value = {
+            "run_uuid": "test-uuid",
+            "scenarios": [],
+            "timestamp": "2023-05-22T14:55:02Z",
+            "job_status": True,
+            "node_summary_infos": [],
+            "node_taints": [],
+            "kubernetes_objects_count": {},
+            "network_plugins": [],
+        }
+
+        mock_result = Mock()
+        mock_result.__iter__ = Mock(return_value=iter([mock_hit]))
+
+        mock_search = Mock()
+        mock_search.filter.return_value = mock_search
+        mock_search.execute.return_value = mock_result
+        mock_search_class.return_value = mock_search
+
+        results = elastic.search_telemetry("test-uuid", "test-index")
+        self.assertEqual(len(results), 1)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    @patch("krkn_lib.elastic.krkn_elastic.Search")
+    def test_search_telemetry_not_found(
+        self, mock_search_class, mock_elasticsearch
+    ):
+        """Test telemetry search when index not found"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        mock_search = Mock()
+        mock_search.filter.return_value = mock_search
+        mock_search.execute.side_effect = NotFoundError("Index not found")
+        mock_search_class.return_value = mock_search
+
+        results = elastic.search_telemetry("test-uuid", "test-index")
+        self.assertEqual(len(results), 0)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_upload_metrics_exception(self, mock_elasticsearch):
+        """Test upload metrics with exception during push"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        # Mock push_metric to return error
+        with patch.object(elastic, 'push_metric', return_value=-1):
+            raw_data = [
+                {
+                    "name": "test-metric",
+                    "timestamp": datetime.datetime.now(),
+                    "value": 3.14,
+                }
+            ]
+            result = elastic.upload_metrics_to_elasticsearch(
+                "test-uuid", raw_data, "test-index"
+            )
+            # Should still complete but log errors
+            self.assertGreaterEqual(result, 0)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_upload_metrics_invalid_data(self, mock_elasticsearch):
+        """Test upload metrics with invalid metric data that raises exception"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        # Mock ElasticMetric to raise exception
+        raw_data = [
+            {
+                "name": "test-metric",
+                "timestamp": datetime.datetime.now(),
+                "value": 3.14,
+            }
+        ]
+
+        with patch('krkn_lib.elastic.krkn_elastic.ElasticMetric', side_effect=Exception("Invalid data")):
+            result = elastic.upload_metrics_to_elasticsearch(
+                "test-uuid", raw_data, "test-index"
+            )
+            # Should return -1 on exception
+            self.assertEqual(result, -1)
+
+    @patch("krkn_lib.elastic.krkn_elastic.Elasticsearch")
+    def test_push_telemetry_exception(self, mock_elasticsearch):
+        """Test push telemetry with exception"""
+        mock_elasticsearch.return_value = self.mock_es
+        elastic = KrknElastic(self.safe_logger, "http://localhost", 9200)
+
+        telemetry_data = {
+            "run_uuid": "test-uuid",
+            "scenarios": [],
+            "timestamp": "2023-05-22T14:55:02Z",
+            "job_status": True,
+            "node_summary_infos": [],
+            "node_taints": [],
+            "kubernetes_objects_count": {},
+            "network_plugins": [],
+        }
+        telemetry = ChaosRunTelemetry(json_dict=telemetry_data)
+
+        # Mock to raise exception during save
+        with patch('krkn_lib.models.elastic.models.ElasticChaosRunTelemetry.save', side_effect=Exception("Save failed")):
+            result = elastic.push_telemetry(telemetry, "test-index")
+            self.assertEqual(result, -1)
+
+
+class TestKrknElasticIntegration(BaseTest):
+    """Integration tests that require actual Elasticsearch (original tests)"""
+
+    def setUp(self):
+        """Skip tests if Elasticsearch is not configured"""
+        if self.lib_elastic is None:
+            self.skipTest("Elasticsearch not configured")
 
     def test_push_search_alert(self):
         run_uuid = str(uuid.uuid4())
@@ -114,57 +596,3 @@ class TestKrknElastic(BaseTest):
             metric[0].timestamp, time_now.strftime("%Y-%m-%dT%H:%M:%S.%f")
         )
         self.assertEqual(metric[0].value, 3.14)
-
-    def test_search_alert_not_existing(self):
-        self.assertEqual(
-            len(self.lib_elastic.search_alert("notexisting", "notexisting")), 0
-        )
-
-    def test_search_metric_not_existing(self):
-        self.assertEqual(
-            len(self.lib_elastic.search_metric("notexisting", "notexisting")),
-            0,
-        )
-
-    def test_search_telemetry_not_existing(self):
-        self.assertEqual(
-            len(
-                self.lib_elastic.search_telemetry("notexisting", "notexisting")
-            ),
-            0,
-        )
-
-    def test_upload_correct(self):
-        timestamp = datetime.datetime.now()
-        run_uuid = str(uuid.uuid4())
-        index = "chaos_test"
-        time = self.lib_elastic.upload_data_to_elasticsearch(
-            {"timestamp": timestamp, "run_uuid": run_uuid}, index
-        )
-        self.assertGreater(time, 0)
-
-    def test_upload_no_index(self):
-        time = self.lib_elastic.upload_data_to_elasticsearch(
-            {"timestamp": datetime.datetime.now()}, ""
-        )
-
-        self.assertEqual(time, 0)
-
-    def test_upload_bad_es_url(self):
-        elastic = KrknElastic(
-            SafeLogger(),
-            "http://localhost",
-        )
-        time = elastic.upload_data_to_elasticsearch(
-            {"timestamp": datetime.datetime.now()}, "chaos_test"
-        )
-
-        self.assertEqual(time, -1)
-
-    def _testupload_blank_es_url(self):
-        es_url = ""
-        with self.assertRaises(Exception):
-            _ = KrknElastic(
-                SafeLogger(),
-                es_url,
-            )


### PR DESCRIPTION
## Description  
Added unit test for `krkn_elastic.py` at `test_krkn_elastic.py`

```
uv pip install pytest-cov
pytest src/krkn_lib/tests/test_krkn_elastic.py::TestKrknElasticWithMock -v --cov=krkn_lib.elastic.krkn_elastic --cov-report=term-missing
```
coverage report
```
Name                                   Stmts   Miss  Cover   Missing
--------------------------------------------------------------------
src/krkn_lib/elastic/krkn_elastic.py     121      0   100%
--------------------------------------------------------------------
TOTAL                                    121      0   100%
```
## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  

#221 