### PR TITLE
fix: remove duplicate assignment in get_nodes_infos()

### DIFF
--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -2536,7 +2536,6 @@ class KrknKubernetes:
                     node_info.nodes_type = "unknown"
 
                 node_info.architecture = node.status.node_info.architecture
-                node_info.architecture = node.status.node_info.architecture
                 node_info.kernel_version = node.status.node_info.kernel_version
                 node_info.kubelet_version = (
                     node.status.node_info.kubelet_version


### PR DESCRIPTION
## Description  
Fixes #234

Remove duplicate assignment of `node_info.architecture` in `get_nodes_infos()` method.

The same line was repeated twice consecutively (lines 2539-2540). Removed the redundant line.

## Documentation  
- [ ] **Is documentation needed for this update?**

No documentation needed - this is a code cleanup with no API changes.

## Related Documentation PR (if applicable)  
N/A
