### PR TITLE
fix: add None check for container_statuses in get_pod_info()

### DIFF
--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -1955,13 +1955,14 @@ class KrknKubernetes:
                         )
                     )
 
-                for i, container in enumerate(
-                    response.status.container_statuses
-                ):
-                    container_list[i].ready = container.ready
-                    container_list[i].containerId = (
-                        response.status.container_statuses[i].container_id
-                    )
+                if response.status.container_statuses:
+                    for i, container in enumerate(
+                        response.status.container_statuses
+                    ):
+                        container_list[i].ready = container.ready
+                        container_list[i].containerId = (
+                            response.status.container_statuses[i].container_id
+                        )
 
                 # Create a list of volumes associated with the pod
                 volume_list = []


### PR DESCRIPTION
## Description  
Fixes #239

Add `None` check for `container_statuses` in `get_pod_info()` to prevent `TypeError`.

**Problem:** `response.status.container_statuses` can be `None` when a pod is in `Pending` state (before containers are created), causing `TypeError: 'NoneType' object is not iterable`.

**Solution:** Added `if response.status.container_statuses:` guard before iterating.

## Documentation  
- [ ] **Is documentation needed for this update?**

No documentation needed - this is a bug fix.

## Related Documentation PR (if applicable)  
N/A
