### PR TITLE
Adding tag, fips, ipsec, etcd

### DIFF
--- a/src/krkn_lib/k8s/pod_monitor/pod_monitor.py
+++ b/src/krkn_lib/k8s/pod_monitor/pod_monitor.py
@@ -178,15 +178,15 @@ def _monitor_pods(
                             w.stop()
                             return snapshot
 
-                        if (
-                            len(deleted_parent_pods) > 0
-                            and len(deleted_parent_pods) == len(restored_pods)
-                        ):
+                        if len(deleted_parent_pods) > 0 and len(
+                            deleted_parent_pods
+                        ) == len(restored_pods):
                             # Check that restored pods are actually new pods
                             # (not just initial pods that stayed ready)
                             # by verifying they have ADDED events
                             new_pods_count = sum(
-                                1 for pod_name in restored_pods
+                                1
+                                for pod_name in restored_pods
                                 if pod_name in snapshot.added_pods
                             )
                             if new_pods_count == len(deleted_parent_pods):
@@ -212,9 +212,7 @@ def _monitor_pods(
                             had_disruption = any(
                                 any(
                                     ev.status == PodStatus.NOT_READY
-                                    for ev in snapshot.pods[
-                                        p
-                                    ].status_changes
+                                    for ev in snapshot.pods[p].status_changes
                                 )
                                 for p in snapshot.initial_pods
                                 if p in snapshot.pods
@@ -229,9 +227,7 @@ def _monitor_pods(
                                 return snapshot
 
             # If we exit the loop normally (timeout reached), we're done
-            logging.info(
-                "Watch stream completed normally (timeout reached)"
-            )
+            logging.info("Watch stream completed normally (timeout reached)")
             w.stop()
             return snapshot
 

--- a/src/krkn_lib/models/elastic/models.py
+++ b/src/krkn_lib/models/elastic/models.py
@@ -176,6 +176,10 @@ class ElasticChaosRunTelemetry(Document):
     cluster_version = Text()
     major_version = Text()
     build_url = Text()
+    tag = Text()
+    fips_enabled = Boolean()
+    etcd_encryption_enabled = Boolean()
+    ipsec_enabled = Boolean()
     job_status = Boolean()
     run_uuid = Text(fields={"keyword": Keyword()})
     health_checks = Nested(ElasticHealthChecks, multi=True)
@@ -331,6 +335,12 @@ class ElasticChaosRunTelemetry(Document):
         self.job_status = chaos_run_telemetry.job_status
         self.major_version = chaos_run_telemetry.major_version
         self.build_url = chaos_run_telemetry.build_url
+        self.tag = chaos_run_telemetry.tag
+        self.fips_enabled = chaos_run_telemetry.fips_enabled
+        self.etcd_encryption_enabled = (
+            chaos_run_telemetry.etcd_encryption_enabled
+        )
+        self.ipsec_enabled = chaos_run_telemetry.ipsec_enabled
 
         if chaos_run_telemetry.error_logs:
             self.error_logs = [
@@ -346,18 +356,10 @@ class ElasticChaosRunTelemetry(Document):
         if chaos_run_telemetry.overall_resiliency_report:
             overall_report = chaos_run_telemetry.overall_resiliency_report
             self.overall_resiliency_report = ElasticResiliencyReport(
-                scenarios=(
-                    overall_report.scenarios
-                ),
-                resiliency_score=(
-                    overall_report.resiliency_score
-                ),
-                passed_slos=(
-                    overall_report.passed_slos
-                ),
-                total_slos=(
-                    overall_report.total_slos
-                ),
+                scenarios=(overall_report.scenarios),
+                resiliency_score=(overall_report.resiliency_score),
+                passed_slos=(overall_report.passed_slos),
+                total_slos=(overall_report.total_slos),
             )
         else:
             self.overall_resiliency_report = None

--- a/src/krkn_lib/models/k8s/models.py
+++ b/src/krkn_lib/models/k8s/models.py
@@ -409,7 +409,7 @@ class ResiliencyReport:
         json_object: dict = None,
         resiliency_score: int = 0,
         passed_slos: int = 0,
-        total_slos: int = 0
+        total_slos: int = 0,
     ):
         self.scenarios = {}
         self.resiliency_score = resiliency_score

--- a/src/krkn_lib/models/pod_monitor/models.py
+++ b/src/krkn_lib/models/pod_monitor/models.py
@@ -153,8 +153,7 @@ class PodsSnapshot:
                         # pod stayed ready but was restarted
                         # or has a failed container
                         recovery_time = (
-                            ready_status.timestamp
-                            - status_change.timestamp
+                            ready_status.timestamp - status_change.timestamp
                         )
 
                         # Ensure non-negative time (handle clock skew)
@@ -173,9 +172,7 @@ class PodsSnapshot:
                 # if there's a DELETION_SCHEDULED event
                 # looks for the rescheduled pod
                 # and calculates its scheduling and readiness time
-                if status_change.status in (
-                    PodStatus.DELETION_SCHEDULED,
-                ):
+                if status_change.status in (PodStatus.DELETION_SCHEDULED,):
                     rescheduled_pod = self._find_rescheduled_pod(pod_name)
                     if not rescheduled_pod:
                         pods_status.unrecovered.append(

--- a/src/krkn_lib/models/telemetry/models.py
+++ b/src/krkn_lib/models/telemetry/models.py
@@ -558,6 +558,23 @@ class ChaosRunTelemetry:
     """
     Build url if run in CI
     """
+    tag: str = ""
+    """
+    Tag to compare similar job
+    """
+    fips_enabled: bool = False
+    """
+    Whether FIPS (Federal Information Processing Standards) is enabled
+    in the cluster
+    """
+    etcd_encryption_enabled: bool = False
+    """
+    Whether etcd encryption is enabled in the cluster
+    """
+    ipsec_enabled: bool = False
+    """
+    Whether IPsec is enabled in the cluster
+    """
     error_logs: list[dict] = None
     """
     Error logs collected during chaos run
@@ -619,6 +636,12 @@ class ChaosRunTelemetry:
             )
             self.job_status = json_dict.get("job_status")
             self.build_url = json_dict.get("build_url")
+            self.tag = json_dict.get("tag")
+            self.fips_enabled = json_dict.get("fips_enabled", False)
+            self.etcd_encryption_enabled = json_dict.get(
+                "etcd_encryption_enabled", False
+            )
+            self.ipsec_enabled = json_dict.get("ipsec_enabled", False)
             self.error_logs = json_dict.get("error_logs")
 
             if json_dict.get("overall_resiliency_report"):

--- a/src/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py
+++ b/src/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py
@@ -110,6 +110,13 @@ class KrknTelemetryKubernetes:
             if scenario.exit_status > 0:
                 chaos_telemetry.job_status = False
 
+        # Collect security and encryption settings
+        chaos_telemetry.fips_enabled = self.__kubecli.is_fips_enabled()
+        chaos_telemetry.etcd_encryption_enabled = (
+            self.__kubecli.is_etcd_encryption_enabled()
+        )
+        chaos_telemetry.ipsec_enabled = self.__kubecli.is_ipsec_enabled()
+
     def send_telemetry(
         self,
         telemetry_config: dict,

--- a/src/krkn_lib/telemetry/ocp/krkn_telemetry_openshift.py
+++ b/src/krkn_lib/telemetry/ocp/krkn_telemetry_openshift.py
@@ -1,5 +1,5 @@
-import ast
 import datetime
+import json
 import logging
 import os
 import threading
@@ -78,6 +78,13 @@ class KrknTelemetryOpenshift(KrknTelemetryKubernetes):
         chaos_telemetry.network_plugins = (
             self.__ocpcli.get_cluster_network_plugins()
         )
+
+        # Collect security and encryption settings
+        chaos_telemetry.fips_enabled = self.__ocpcli.is_fips_enabled()
+        chaos_telemetry.etcd_encryption_enabled = (
+            self.__ocpcli.is_etcd_encryption_enabled()
+        )
+        chaos_telemetry.ipsec_enabled = self.__ocpcli.is_ipsec_enabled()
 
         vm_number = self.get_vm_number()
         if vm_number > 0:
@@ -256,7 +263,7 @@ class KrknTelemetryOpenshift(KrknTelemetryKubernetes):
                 if data[1] != 200:
                     return 0
 
-                json_obj = ast.literal_eval(data[0])
+                json_obj = json.loads(data[0])
                 return len(json_obj["items"])
             except Exception:
                 logging.info("failed to parse virtualmachines API")

--- a/src/krkn_lib/tests/base_test.py
+++ b/src/krkn_lib/tests/base_test.py
@@ -635,6 +635,10 @@ class BaseTest(unittest.TestCase):
             "major_verison": "4.18",
             "job_status": True,
             "build_url": "https://github.com/krkn-chaos/krkn-lib/actions/runs/16724993547",  # NOQA
+            "tag": "github-action",
+            "fips_enabled": True,
+            "etcd_encryption_enabled": True,
+            "ipsec_enabled": False,
             "error_logs": [
                 {
                     "timestamp": "2023-05-22T14:55:05Z",

--- a/src/krkn_lib/tests/test_krkn_elastic_models.py
+++ b/src/krkn_lib/tests/test_krkn_elastic_models.py
@@ -269,6 +269,10 @@ class TestKrknElasticModels(BaseTest):
         self.assertEqual(elastic_telemetry.cloud_infrastructure, "AWS")
         self.assertEqual(elastic_telemetry.cloud_type, "EC2")
         self.assertEqual(elastic_telemetry.run_uuid, run_uuid)
+        self.assertEqual(elastic_telemetry.tag, "github-action")
+        self.assertTrue(elastic_telemetry.fips_enabled)
+        self.assertTrue(elastic_telemetry.etcd_encryption_enabled)
+        self.assertFalse(elastic_telemetry.ipsec_enabled)
         self.assertEqual(
             elastic_telemetry.build_url,
             "https://github.com/krkn-chaos/krkn-lib/actions/runs/16724993547",
@@ -294,22 +298,12 @@ class TestKrknElasticModels(BaseTest):
         # overall_resiliency_report validation
         overall_report = elastic_telemetry.overall_resiliency_report
         self.assertIsNotNone(overall_report)
+        self.assertEqual(overall_report.resiliency_score, 90)
+        self.assertEqual(overall_report.passed_slos, 4)
+        self.assertEqual(overall_report.total_slos, 5)
+        self.assertIsNotNone(overall_report.scenarios)
         self.assertEqual(
-            overall_report.resiliency_score, 90
-        )
-        self.assertEqual(
-            overall_report.passed_slos, 4
-        )
-        self.assertEqual(
-            overall_report.total_slos, 5
-        )
-        self.assertIsNotNone(
-            overall_report.scenarios
-        )
-        self.assertEqual(
-            overall_report.scenarios.to_dict().get(
-                "example_scenario.yaml"
-            ),
+            overall_report.scenarios.to_dict().get("example_scenario.yaml"),
             95,
         )
 

--- a/src/krkn_lib/tests/test_krkn_kubernetes_create.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_create.py
@@ -11,8 +11,9 @@ Assisted By: Claude Code
 
 import logging
 import tempfile
-import unittest
 import time
+import unittest
+
 import yaml
 from jinja2 import Environment, FileSystemLoader
 from kubernetes.client import ApiException
@@ -22,6 +23,7 @@ from krkn_lib.tests import BaseTest
 
 class KrknKubernetesTestsCreate(BaseTest):
     """Test create operations on Kubernetes cluster."""
+
     def test_create_pod(self):
         """Test creating a pod and waiting for it to be running."""
         namespace = "test-cp-" + self.get_random_string(10)

--- a/src/krkn_lib/tests/test_krkn_kubernetes_get.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_get.py
@@ -347,6 +347,23 @@ class KrknKubernetesTestsGet(BaseTest):
                 container_id[0],
             )
 
+    def test_is_fips_enabled(self):
+        """Test FIPS detection returns a boolean."""
+        result = self.lib_k8s.is_fips_enabled()
+        self.assertIsInstance(result, bool)
+
+    def test_is_etcd_encryption_enabled(self):
+        """Test etcd encryption detection returns a boolean."""
+        result = self.lib_k8s.is_etcd_encryption_enabled()
+        # For vanilla Kubernetes, should return False
+        self.assertIsInstance(result, bool)
+        self.assertFalse(result)
+
+    def test_is_ipsec_enabled(self):
+        """Test IPsec detection returns a boolean."""
+        result = self.lib_k8s.is_ipsec_enabled()
+        self.assertIsInstance(result, bool)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/krkn_lib/tests/test_krkn_kubernetes_pods_monitor_models.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_pods_monitor_models.py
@@ -186,9 +186,7 @@ class TestMonitorPodsMonitorModels(unittest.TestCase):
         parent_pod.name = "parent-pod"
         parent_pod.namespace = "parent-ns"
         deletion_ts = time.time() - 20
-        deletion_event = PodEvent(
-            timestamp=deletion_ts
-        )
+        deletion_event = PodEvent(timestamp=deletion_ts)
         deletion_event.status = PodStatus.DELETION_SCHEDULED
         parent_pod.status_changes.append(deletion_event)
 

--- a/src/krkn_lib/tests/test_krkn_prometheus.py
+++ b/src/krkn_lib/tests/test_krkn_prometheus.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 from unittest.mock import Mock, patch
+
 from krkn_lib.prometheus.krkn_prometheus import KrknPrometheus
 from krkn_lib.tests import BaseTest
 
@@ -9,20 +10,21 @@ class TestKrknPrometheus(BaseTest):
     """
     Integration tests for KrknPrometheus class.
     """
+
     url = "http://localhost:9090"
 
     def setUp(self):
         logging.disable(logging.NOTSET)
         logging.basicConfig(
             level=logging.DEBUG,
-            format='%(levelname)s: %(message)s',
-            force=True
+            format="%(levelname)s: %(message)s",
+            force=True,
         )
 
     def test_constructor_success(self):
         """Test successful initialization of KrknPrometheus."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_instance = Mock()
             mock_prom.return_value = mock_instance
@@ -35,7 +37,7 @@ class TestKrknPrometheus(BaseTest):
     def test_constructor_with_bearer_token(self):
         """Test initialization with bearer token."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             bearer_token = "test_token_12345"
             mock_instance = Mock()
@@ -45,16 +47,16 @@ class TestKrknPrometheus(BaseTest):
 
             # Verify the headers were set correctly
             call_args = mock_prom.call_args
-            self.assertIn('headers', call_args.kwargs)
+            self.assertIn("headers", call_args.kwargs)
             self.assertEqual(
-                call_args.kwargs['headers']['Authorization'],
-                f"Bearer {bearer_token}"
+                call_args.kwargs["headers"]["Authorization"],
+                f"Bearer {bearer_token}",
             )
 
     def test_constructor_exception_handling(self):
         """Test that constructor exits on initialization failure."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_prom.side_effect = Exception("Connection failed")
 
@@ -66,7 +68,7 @@ class TestKrknPrometheus(BaseTest):
     def test_process_prom_query_in_range_success(self):
         """Test successful range query execution."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
@@ -75,7 +77,7 @@ class TestKrknPrometheus(BaseTest):
             expected_result = [
                 {
                     "metric": {"instance": "node1", "pod": "test_pod"},
-                    "values": [[1699357840, "0.1"], [1699357850, "0.2"]]
+                    "values": [[1699357840, "0.1"], [1699357850, "0.2"]],
                 }
             ]
             mock_client.custom_query_range.return_value = expected_result
@@ -99,7 +101,7 @@ class TestKrknPrometheus(BaseTest):
     def test_process_prom_query_in_range_default_times(self):
         """Test range query with default start/end times."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
@@ -117,7 +119,7 @@ class TestKrknPrometheus(BaseTest):
     def test_process_prom_query_in_range_custom_granularity(self):
         """Test range query with custom granularity."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
@@ -134,12 +136,12 @@ class TestKrknPrometheus(BaseTest):
             )
 
             call_args = mock_client.custom_query_range.call_args
-            self.assertEqual(call_args.kwargs['step'], "30s")
+            self.assertEqual(call_args.kwargs["step"], "30s")
 
     def test_process_prom_query_in_range_exception(self):
         """Test exception handling in range query."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
@@ -158,16 +160,13 @@ class TestKrknPrometheus(BaseTest):
     def test_process_query_success(self):
         """Test successful instant query execution."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
 
             expected_result = [
-                {
-                    "metric": {"instance": "node1"},
-                    "value": [1699357840, "0.5"]
-                }
+                {"metric": {"instance": "node1"}, "value": [1699357840, "0.5"]}
             ]
             mock_client.custom_query.return_value = expected_result
 
@@ -184,7 +183,7 @@ class TestKrknPrometheus(BaseTest):
     def test_process_query_exception(self):
         """Test exception handling in instant query."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
@@ -203,7 +202,7 @@ class TestKrknPrometheus(BaseTest):
     def test_process_alert_info_severity(self):
         """Test process_alert with info severity level."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
@@ -212,9 +211,9 @@ class TestKrknPrometheus(BaseTest):
                 {
                     "metric": {
                         "container": "test-container",
-                        "endpoint": "test-endpoint"
+                        "endpoint": "test-endpoint",
                     },
-                    "values": [[1699357840, "0.1"]]
+                    "values": [[1699357840, "0.1"]],
                 }
             ]
             mock_client.custom_query_range.return_value = mock_result
@@ -228,7 +227,7 @@ class TestKrknPrometheus(BaseTest):
                     "endpoint: {{$labels.endpoint}}, "
                     "value: {{$value}}"
                 ),
-                "severity": "info"
+                "severity": "info",
             }
             start_time = datetime.datetime.now() - datetime.timedelta(days=1)
             end_time = datetime.datetime.now()
@@ -246,7 +245,7 @@ class TestKrknPrometheus(BaseTest):
     def test_process_alert_debug_severity(self):
         """Test process_alert with debug severity level."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
@@ -254,7 +253,7 @@ class TestKrknPrometheus(BaseTest):
             mock_result = [
                 {
                     "metric": {"pod": "test-pod"},
-                    "values": [[1699357840, "1.5"]]
+                    "values": [[1699357840, "1.5"]],
                 }
             ]
             mock_client.custom_query_range.return_value = mock_result
@@ -264,13 +263,13 @@ class TestKrknPrometheus(BaseTest):
             alert = {
                 "expr": "test_query",
                 "description": "pod: {{$labels.pod}}, value: {{$value}}",
-                "severity": "debug"
+                "severity": "debug",
             }
 
             timestamp, log_output = prom_cli.process_alert(
                 alert,
                 datetime.datetime.now() - datetime.timedelta(hours=1),
-                datetime.datetime.now()
+                datetime.datetime.now(),
             )
 
             self.assertIsNotNone(timestamp)
@@ -281,7 +280,7 @@ class TestKrknPrometheus(BaseTest):
     def test_process_alert_warning_severity(self):
         """Test process_alert with warning severity level."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
@@ -289,7 +288,7 @@ class TestKrknPrometheus(BaseTest):
             mock_result = [
                 {
                     "metric": {"instance": "node1"},
-                    "values": [[1699357840, "90"]]
+                    "values": [[1699357840, "90"]],
                 }
             ]
             mock_client.custom_query_range.return_value = mock_result
@@ -301,13 +300,13 @@ class TestKrknPrometheus(BaseTest):
                 "description": (
                     "High CPU on {{$labels.instance}}: {{$value}}%"
                 ),
-                "severity": "warning"
+                "severity": "warning",
             }
 
             timestamp, log_output = prom_cli.process_alert(
                 alert,
                 datetime.datetime.now() - datetime.timedelta(hours=1),
-                datetime.datetime.now()
+                datetime.datetime.now(),
             )
 
             self.assertIsNotNone(timestamp)
@@ -318,16 +317,13 @@ class TestKrknPrometheus(BaseTest):
     def test_process_alert_error_severity(self):
         """Test process_alert with error severity level."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
 
             mock_result = [
-                {
-                    "metric": {"service": "api"},
-                    "values": [[1699357840, "500"]]
-                }
+                {"metric": {"service": "api"}, "values": [[1699357840, "500"]]}
             ]
             mock_client.custom_query_range.return_value = mock_result
 
@@ -338,13 +334,13 @@ class TestKrknPrometheus(BaseTest):
                 "description": (
                     "Error on {{$labels.service}}: code {{$value}}"
                 ),
-                "severity": "error"
+                "severity": "error",
             }
 
             timestamp, log_output = prom_cli.process_alert(
                 alert,
                 datetime.datetime.now() - datetime.timedelta(hours=1),
-                datetime.datetime.now()
+                datetime.datetime.now(),
             )
 
             self.assertIsNotNone(timestamp)
@@ -355,16 +351,13 @@ class TestKrknPrometheus(BaseTest):
     def test_process_alert_critical_severity(self):
         """Test process_alert with critical severity level."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
 
             mock_result = [
-                {
-                    "metric": {"cluster": "prod"},
-                    "values": [[1699357840, "0"]]
-                }
+                {"metric": {"cluster": "prod"}, "values": [[1699357840, "0"]]}
             ]
             mock_client.custom_query_range.return_value = mock_result
 
@@ -373,13 +366,13 @@ class TestKrknPrometheus(BaseTest):
             alert = {
                 "expr": "cluster_down",
                 "description": "Cluster {{$labels.cluster}} is down!",
-                "severity": "critical"
+                "severity": "critical",
             }
 
             timestamp, log_output = prom_cli.process_alert(
                 alert,
                 datetime.datetime.now() - datetime.timedelta(hours=1),
-                datetime.datetime.now()
+                datetime.datetime.now(),
             )
 
             self.assertIsNotNone(timestamp)
@@ -390,7 +383,7 @@ class TestKrknPrometheus(BaseTest):
     def test_process_alert_invalid_severity(self):
         """Test process_alert with invalid severity level."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
@@ -400,13 +393,13 @@ class TestKrknPrometheus(BaseTest):
             alert = {
                 "expr": "test_query",
                 "description": "Test description",
-                "severity": "not_exists"
+                "severity": "not_exists",
             }
 
             timestamp, log_output = prom_cli.process_alert(
                 alert,
                 datetime.datetime.now() - datetime.timedelta(hours=1),
-                datetime.datetime.now()
+                datetime.datetime.now(),
             )
 
             # Should return timestamp and log_output with error message
@@ -417,22 +410,19 @@ class TestKrknPrometheus(BaseTest):
     def test_process_alert_missing_expr(self):
         """Test process_alert with missing expr field."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
 
             prom_cli = KrknPrometheus(self.url)
 
-            alert = {
-                "description": "Test description",
-                "severity": "info"
-            }
+            alert = {"description": "Test description", "severity": "info"}
 
             timestamp, log_output = prom_cli.process_alert(
                 alert,
                 datetime.datetime.now() - datetime.timedelta(hours=1),
-                datetime.datetime.now()
+                datetime.datetime.now(),
             )
 
             # Should return timestamp and log_output with error message
@@ -444,22 +434,19 @@ class TestKrknPrometheus(BaseTest):
     def test_process_alert_missing_description(self):
         """Test process_alert with missing description field."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
 
             prom_cli = KrknPrometheus(self.url)
 
-            alert = {
-                "expr": "test_query",
-                "severity": "info"
-            }
+            alert = {"expr": "test_query", "severity": "info"}
 
             timestamp, log_output = prom_cli.process_alert(
                 alert,
                 datetime.datetime.now() - datetime.timedelta(hours=1),
-                datetime.datetime.now()
+                datetime.datetime.now(),
             )
 
             # Should return timestamp and log_output with error message
@@ -471,22 +458,19 @@ class TestKrknPrometheus(BaseTest):
     def test_process_alert_missing_severity(self):
         """Test process_alert with missing severity field."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
 
             prom_cli = KrknPrometheus(self.url)
 
-            alert = {
-                "expr": "test_query",
-                "description": "Test description"
-            }
+            alert = {"expr": "test_query", "description": "Test description"}
 
             timestamp, log_output = prom_cli.process_alert(
                 alert,
                 datetime.datetime.now() - datetime.timedelta(hours=1),
-                datetime.datetime.now()
+                datetime.datetime.now(),
             )
 
             # Should return timestamp and log_output with error message
@@ -498,7 +482,7 @@ class TestKrknPrometheus(BaseTest):
     def test_process_alert_no_records(self):
         """Test process_alert when query returns no records."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_client = Mock()
             mock_prom.return_value = mock_client
@@ -511,13 +495,13 @@ class TestKrknPrometheus(BaseTest):
             alert = {
                 "expr": "non_existent_metric",
                 "description": "Test",
-                "severity": "info"
+                "severity": "info",
             }
 
             timestamp, log_output = prom_cli.process_alert(
                 alert,
                 datetime.datetime.now() - datetime.timedelta(hours=1),
-                datetime.datetime.now()
+                datetime.datetime.now(),
             )
 
             self.assertIsNone(timestamp)
@@ -526,7 +510,7 @@ class TestKrknPrometheus(BaseTest):
     def test_parse_metric_standard_replacement(self):
         """Test parse_metric with standard label and value replacement."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_prom.return_value = Mock()
             prom_cli = KrknPrometheus(self.url)
@@ -558,7 +542,7 @@ class TestKrknPrometheus(BaseTest):
     def test_parse_metric_no_value(self):
         """Test parse_metric with empty values array."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_prom.return_value = Mock()
             prom_cli = KrknPrometheus(self.url)
@@ -590,7 +574,7 @@ class TestKrknPrometheus(BaseTest):
     def test_parse_metric_underscore_label(self):
         """Test parse_metric with labels containing underscores."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_prom.return_value = Mock()
             prom_cli = KrknPrometheus(self.url)
@@ -624,7 +608,7 @@ class TestKrknPrometheus(BaseTest):
     def test_parse_metric_multiple_values(self):
         """Test parse_metric with multiple values in the series."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_prom.return_value = Mock()
             prom_cli = KrknPrometheus(self.url)
@@ -634,7 +618,7 @@ class TestKrknPrometheus(BaseTest):
                 "values": [
                     [1699357840, "0.1"],
                     [1699357850, "0.2"],
-                    [1699357860, "0.3"]
+                    [1699357860, "0.3"],
                 ],
             }
 
@@ -649,7 +633,7 @@ class TestKrknPrometheus(BaseTest):
     def test_parse_metric_missing_label(self):
         """Test parse_metric when a label doesn't exist in the metric."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_prom.return_value = Mock()
             prom_cli = KrknPrometheus(self.url)
@@ -670,7 +654,7 @@ class TestKrknPrometheus(BaseTest):
     def test_parse_metric_no_placeholders(self):
         """Test parse_metric with description containing no placeholders."""
         with patch(
-            'krkn_lib.prometheus.krkn_prometheus.PrometheusConnect'
+            "krkn_lib.prometheus.krkn_prometheus.PrometheusConnect"
         ) as mock_prom:
             mock_prom.return_value = Mock()
             prom_cli = KrknPrometheus(self.url)
@@ -680,9 +664,7 @@ class TestKrknPrometheus(BaseTest):
                 "values": [[1699357840, "0.1"]],
             }
 
-            description = (
-                "This is a plain description with no placeholders"
-            )
+            description = "This is a plain description with no placeholders"
 
             result = prom_cli.parse_metric(description, metric)
             self.assertEqual(description, result)


### PR DESCRIPTION
### **User description**
## Description  
Adding ability to tag certain runs for later comparison
Adding more details of cluster configurations with adding fips, etcd, and ipsec details

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add cluster security detection methods for FIPS, etcd encryption, and IPsec

- Extend telemetry models to capture security configuration states

- Implement OpenShift-specific security detection via API calls

- Add comprehensive test coverage for new security detection features

- Support run tagging for easier comparison and analysis


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Kubernetes/OpenShift Cluster"] -->|"detect security settings"| B["is_fips_enabled<br/>is_etcd_encryption_enabled<br/>is_ipsec_enabled"]
  B -->|"collect metadata"| C["ChaosRunTelemetry"]
  C -->|"store in Elasticsearch"| D["ElasticChaosRunTelemetry"]
  C -->|"include tag field"| E["Run Comparison & Analysis"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>krkn_kubernetes.py</strong><dd><code>Add security detection methods for vanilla Kubernetes</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn-lib/pull/260/files#diff-1ffd55969633ceebd8207615315734432ce4dad8be5141101c37bef55f22b091">+79/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>krkn_openshift.py</strong><dd><code>Implement OpenShift-specific security detection via API</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn-lib/pull/260/files#diff-780e28d18722ab951304d49168451c12ea0663740c1bad1039fa63bab840cf62">+129/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add security and tag fields to telemetry model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn-lib/pull/260/files#diff-099fea74947291585a90fd6cb3528ff35993ebc4471252975d2eacb2e4a9062b">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add security fields to Elasticsearch telemetry model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn-lib/pull/260/files#diff-691e67b5d3ecdc39a980cc4e5573e82ecab9a232ccdb519eeceba9ae2c01d2e8">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>krkn_telemetry_kubernetes.py</strong><dd><code>Collect security settings during metadata gathering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn-lib/pull/260/files#diff-64edb5d79e8f3adf48516ac66b348e2d5e176e6d8e21922488e1a19be2140306">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>krkn_telemetry_openshift.py</strong><dd><code>Collect OpenShift security settings in telemetry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn-lib/pull/260/files#diff-2991c0dfa97dfd3573454368d16db9b9ff62c3f07ff89aafc01c6a5317c9a4a8">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>base_test.py</strong><dd><code>Add security fields to test telemetry fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn-lib/pull/260/files#diff-0bc12a3426a0377bc44c55f58e4dc7f1b5cb23cd085934a50f3fe33eeed2ba36">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_krkn_kubernetes_get.py</strong><dd><code>Add unit tests for Kubernetes security detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn-lib/pull/260/files#diff-028e77a81e0a65f6991f8975d8aa9d3a39083cf964b718acd0b722950d8648f6">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_krkn_openshift.py</strong><dd><code>Add comprehensive tests for OpenShift security detection</code>&nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn-lib/pull/260/files#diff-773b45f9f7f21566135e177db07c4b8281c9314f146ea8013928ad4eeba8316d">+299/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_krkn_elastic_models.py</strong><dd><code>Verify security fields in Elasticsearch model tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn-lib/pull/260/files#diff-17b6342c4a4fd71096bb17135a97ca7d31324fc00a4d4985fe6b8aca3ce84026">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_krkn_telemetry_kubernetes.py</strong><dd><code>Test security metadata collection in Kubernetes telemetry</code></dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn-lib/pull/260/files#diff-ee812b10b09a815522cf13861e21de54464a6adda439f59c6b832649263fc806">+22/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_krkn_telemetry_models.py</strong><dd><code>Test security field serialization in telemetry models</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn-lib/pull/260/files#diff-13f4c5ee323fae69c296688c837862bcd0c0ba98ec311fa921fb5ae6540b7fd6">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

