### PR TITLE
Adding vmi specific recovery metrics

### DIFF
--- a/src/krkn_lib/models/elastic/models.py
+++ b/src/krkn_lib/models/elastic/models.py
@@ -88,6 +88,20 @@ class ElasticPodsStatus(InnerDoc):
     error = Text()
 
 
+class ElasticAffectedVMI(InnerDoc):
+    vmi_name = Text(fields={"keyword": Keyword()})
+    namespace = Text()
+    total_recovery_time = Float()
+    vmi_readiness_time = Float()
+    vmi_rescheduling_time = Float()
+
+
+class ElasticVmisStatus(InnerDoc):
+    recovered = Nested(ElasticAffectedVMI, multi=True)
+    unrecovered = Nested(ElasticAffectedVMI, multi=True)
+    error = Text()
+
+
 class ElasticAffectedNodes(InnerDoc):
     node_name = Text(fields={"keyword": Keyword()})
     node_id = Text()
@@ -118,6 +132,7 @@ class ElasticScenarioTelemetry(InnerDoc):
     parameters_base64 = Text()
     parameters = Nested(ElasticScenarioParameters)
     affected_pods = Nested(ElasticPodsStatus)
+    affected_vmis = Nested(ElasticVmisStatus)
     affected_nodes = Nested(ElasticAffectedNodes, multi=True)
 
 
@@ -225,6 +240,25 @@ class ElasticChaosRunTelemetry(Document):
                         for pod in sc.affected_pods.unrecovered
                     ],
                     error=sc.affected_pods.error,
+                ),
+                affected_vmis=ElasticVmisStatus(
+                    recovered=[
+                        ElasticAffectedVMI(
+                            vmi_name=vmi.vmi_name,
+                            namespace=vmi.namespace,
+                            total_recovery_time=vmi.total_recovery_time,
+                            vmi_readiness_time=vmi.vmi_readiness_time,
+                            vmi_rescheduling_time=vmi.vmi_rescheduling_time,
+                        )
+                        for vmi in sc.affected_vmis.recovered
+                    ],
+                    unrecovered=[
+                        ElasticAffectedVMI(
+                            vmi_name=vmi.vmi_name, namespace=vmi.namespace
+                        )
+                        for vmi in sc.affected_vmis.unrecovered
+                    ],
+                    error=sc.affected_vmis.error,
                 ),
                 affected_nodes=[
                     ElasticAffectedNodes(

--- a/src/krkn_lib/models/k8s/models.py
+++ b/src/krkn_lib/models/k8s/models.py
@@ -218,6 +218,91 @@ class PodsStatus:
             self.unrecovered.append(unrecovered)
 
 
+class AffectedVMI:
+    """
+    A VMI affected by a chaos scenario
+    """
+
+    vmi_name: str
+    """
+    Name of the VMI
+    """
+    namespace: str
+    """
+    Namespace of the VMI
+    """
+    vmi_rescheduling_time: float
+    """
+    The time that the cluster took to reschedule
+    the VMI after the chaos scenario
+    """
+    vmi_readiness_time: float
+    """
+    The time the VMI took to become ready after being scheduled
+    """
+    total_recovery_time: float
+    """
+    Total amount of time the VMI took to become ready
+    """
+
+    def __init__(
+        self,
+        vmi_name: str,
+        namespace: str,
+        total_recovery_time: float = None,
+        vmi_readiness_time: float = None,
+        vmi_rescheduling_time: float = None,
+    ):
+        self.vmi_name = vmi_name
+        self.namespace = namespace
+        self.total_recovery_time = total_recovery_time
+        self.vmi_readiness_time = vmi_readiness_time
+        self.vmi_rescheduling_time = vmi_rescheduling_time
+
+
+class VmisStatus:
+    """
+    Return value of wait_for_vmis_to_become_ready containing the list
+    of the VMIs that did recover (vmi_name, namespace,
+    time needed to become ready) and the list of VMIs that did
+    not recover from the chaos
+    """
+
+    recovered: list[AffectedVMI]
+    unrecovered: list[AffectedVMI]
+
+    def __init__(self, json_object: str = None):
+        self.recovered = []
+        self.unrecovered = []
+        self.error = None
+        if json_object:
+            for recovered in json_object["recovered"]:
+                self.recovered.append(
+                    AffectedVMI(
+                        recovered["vmi_name"],
+                        recovered["namespace"],
+                        float(recovered["total_recovery_time"]),
+                        float(recovered["vmi_readiness_time"]),
+                        float(recovered["vmi_rescheduling_time"]),
+                    )
+                )
+            for unrecovered in json_object["unrecovered"]:
+                self.unrecovered.append(
+                    AffectedVMI(
+                        unrecovered["vmi_name"],
+                        unrecovered["namespace"],
+                    )
+                )
+            if "error" in json_object:
+                self.error = json_object["error"]
+
+    def merge(self, vmis_status: "VmisStatus"):
+        for recovered in vmis_status.recovered:
+            self.recovered.append(recovered)
+        for unrecovered in vmis_status.unrecovered:
+            self.unrecovered.append(unrecovered)
+
+
 class AffectedNode:
     """
     A node affected by a chaos scenario

--- a/src/krkn_lib/models/telemetry/models.py
+++ b/src/krkn_lib/models/telemetry/models.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 
 import yaml
 
-from krkn_lib.models.k8s import AffectedNode, PodsStatus, ResiliencyReport
+from krkn_lib.models.k8s import AffectedNode, PodsStatus, VmisStatus, ResiliencyReport
 
 relevant_event_reasons: frozenset[str] = frozenset(
     [
@@ -81,6 +81,10 @@ class ScenarioTelemetry:
     """
     Pods affected by the chaos scenario
     """
+    affected_vmis: VmisStatus
+    """
+    VMIs affected by the chaos scenario
+    """
     affected_nodes: list[AffectedNode]
     """
     Nodes affected by the chaos scenario
@@ -112,6 +116,9 @@ class ScenarioTelemetry:
             self.parameters = json_object.get("parameters")
             self.affected_pods = PodsStatus(
                 json_object=json_object.get("affected_pods")
+            )
+            self.affected_vmis = VmisStatus(
+                json_object=json_object.get("affected_vmis")
             )
 
             if json_object.get("affected_nodes") and isinstance(
@@ -163,6 +170,7 @@ class ScenarioTelemetry:
             self.parameters_base64 = ""
             self.parameters = {}
             self.affected_pods = PodsStatus()
+            self.affected_vmis = VmisStatus()
             self.affected_nodes = []
             self.cluster_events = []
 

--- a/src/krkn_lib/tests/base_test.py
+++ b/src/krkn_lib/tests/base_test.py
@@ -535,6 +535,21 @@ class BaseTest(unittest.TestCase):
                         ],
                         "error": "some error",
                     },
+                    "affected_vmis": {
+                        "recovered": [
+                            {
+                                "vmi_name": "vmi1",
+                                "namespace": "default",
+                                "total_recovery_time": 15.0,
+                                "vmi_readiness_time": 8.0,
+                                "vmi_rescheduling_time": 3.0,
+                            }
+                        ],
+                        "unrecovered": [
+                            {"vmi_name": "vmi2", "namespace": "default"}
+                        ],
+                        "error": "some vmi error",
+                    },
                     "affected_nodes": [
                         {
                             "node_name": "kind-control-plane",

--- a/src/krkn_lib/tests/test_krkn_elastic_models.py
+++ b/src/krkn_lib/tests/test_krkn_elastic_models.py
@@ -97,6 +97,61 @@ class TestKrknElasticModels(BaseTest):
             .namespace,
             "default",
         )
+        # scenarios -> affected_vmis
+        self.assertEqual(
+            len(elastic_telemetry.scenarios[0].affected_vmis.recovered), 1
+        )
+        self.assertEqual(
+            len(elastic_telemetry.scenarios[0].affected_vmis.unrecovered), 1
+        )
+        self.assertEqual(
+            elastic_telemetry.scenarios[0].affected_vmis.error, "some vmi error"
+        )
+
+        # scenarios -> affected_vmis -> recovered
+        self.assertEqual(
+            elastic_telemetry.scenarios[0].affected_vmis.recovered[0].vmi_name,
+            "vmi1",
+        )
+        self.assertEqual(
+            elastic_telemetry.scenarios[0]
+            .affected_vmis.recovered[0]
+            .namespace,
+            "default",
+        )
+        self.assertEqual(
+            elastic_telemetry.scenarios[0]
+            .affected_vmis.recovered[0]
+            .total_recovery_time,
+            15.0,
+        )
+        self.assertEqual(
+            elastic_telemetry.scenarios[0]
+            .affected_vmis.recovered[0]
+            .vmi_readiness_time,
+            8.0,
+        )
+        self.assertEqual(
+            elastic_telemetry.scenarios[0]
+            .affected_vmis.recovered[0]
+            .vmi_rescheduling_time,
+            3.0,
+        )
+
+        # scenarios -> affected_vmis -> unrecovered
+        self.assertEqual(
+            elastic_telemetry.scenarios[0]
+            .affected_vmis.unrecovered[0]
+            .vmi_name,
+            "vmi2",
+        )
+        self.assertEqual(
+            elastic_telemetry.scenarios[0]
+            .affected_vmis.unrecovered[0]
+            .namespace,
+            "default",
+        )
+
         print(
             "elastic affected nodes"
             + str(


### PR DESCRIPTION
## Description  
Adding vmi specific recovery metrics to help clarify findings in telemetry 

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  