### PR TITLE
feat: add time_to_recovery field to ChaosRunTelemetry

### DIFF
--- a/src/krkn_lib/models/elastic/models.py
+++ b/src/krkn_lib/models/elastic/models.py
@@ -202,6 +202,7 @@ class ElasticChaosRunTelemetry(Document):
     post_virt_checks = Nested(ElasticVirtChecks, multi=True)
     error_logs = Nested(ElasticErrorLog, multi=True)
     overall_resiliency_report = Nested(ElasticResiliencyReport)
+    time_to_recovery = Float()
 
     class Index:
         name = "chaos_run_telemetry"
@@ -375,6 +376,7 @@ class ElasticChaosRunTelemetry(Document):
             chaos_run_telemetry.etcd_encryption_enabled
         )
         self.ipsec_enabled = chaos_run_telemetry.ipsec_enabled
+        self.time_to_recovery = chaos_run_telemetry.time_to_recovery
 
         if chaos_run_telemetry.error_logs:
             self.error_logs = [

--- a/src/krkn_lib/models/telemetry/models.py
+++ b/src/krkn_lib/models/telemetry/models.py
@@ -7,12 +7,7 @@ from datetime import datetime, timezone
 
 import yaml
 
-from krkn_lib.models.k8s import (
-    AffectedNode,
-    PodsStatus,
-    VmisStatus,
-    ResiliencyReport,
-)
+from krkn_lib.models.k8s import AffectedNode, PodsStatus, VmisStatus, ResiliencyReport
 
 relevant_event_reasons: frozenset[str] = frozenset(
     [
@@ -609,6 +604,7 @@ class ChaosRunTelemetry:
         self.health_checks = list[HealthCheck]()
         self.virt_checks = list[VirtCheck]()
         self.error_logs = []
+        self.time_to_recovery: float | None = None
         self.overall_resiliency_report = ResiliencyReport()
         if json_dict is not None:
             scenarios = json_dict.get("scenarios")
@@ -656,6 +652,7 @@ class ChaosRunTelemetry:
             )
             self.ipsec_enabled = json_dict.get("ipsec_enabled", False)
             self.error_logs = json_dict.get("error_logs")
+            self.time_to_recovery = json_dict.get("time_to_recovery")
 
             if json_dict.get("overall_resiliency_report"):
                 report_data = json_dict.get("overall_resiliency_report")

--- a/src/krkn_lib/tests/base_test.py
+++ b/src/krkn_lib/tests/base_test.py
@@ -654,6 +654,7 @@ class BaseTest(unittest.TestCase):
             "fips_enabled": True,
             "etcd_encryption_enabled": True,
             "ipsec_enabled": False,
+            "time_to_recovery": 45.5,
             "error_logs": [
                 {
                     "timestamp": "2023-05-22T14:55:05Z",

--- a/src/krkn_lib/tests/test_krkn_elastic_models.py
+++ b/src/krkn_lib/tests/test_krkn_elastic_models.py
@@ -105,8 +105,7 @@ class TestKrknElasticModels(BaseTest):
             len(elastic_telemetry.scenarios[0].affected_vmis.unrecovered), 1
         )
         self.assertEqual(
-            elastic_telemetry.scenarios[0].affected_vmis.error,
-            "some vmi error",
+            elastic_telemetry.scenarios[0].affected_vmis.error, "some vmi error"
         )
 
         # scenarios -> affected_vmis -> recovered
@@ -329,6 +328,7 @@ class TestKrknElasticModels(BaseTest):
         self.assertTrue(elastic_telemetry.fips_enabled)
         self.assertTrue(elastic_telemetry.etcd_encryption_enabled)
         self.assertFalse(elastic_telemetry.ipsec_enabled)
+        self.assertEqual(elastic_telemetry.time_to_recovery, 45.5)
         self.assertEqual(
             elastic_telemetry.build_url,
             "https://github.com/krkn-chaos/krkn-lib/actions/runs/16724993547",


### PR DESCRIPTION
This adds the data model required for calculating Time to Recovery (TTR). This is part 1 of resolving krkn-chaos/krkn#1235.