### PR TITLE
Improve VMI listing performance using cluster-wide API calls

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
           pip install black flake8 isort
           isort --profile black .
           black --line-length 79 .
-          flake8 .
+          flake8 --max-line-length 79 --extend-ignore E501 .
   build:
     name: Build & Test
     strategy:

--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -1575,25 +1575,53 @@ class KrknKubernetes:
         """
         try:
             vmis_list = []
-            namespaces = self.list_namespaces_by_regex(namespace)
             kwargs = {}
             if label_selector:
                 kwargs["label_selector"] = label_selector
-            for ns in namespaces:
-                vmis = self.custom_object_client.list_namespaced_custom_object(
-                    group="kubevirt.io",
-                    version="v1",
-                    namespace=ns,
-                    plural="virtualmachineinstances",
-                    **kwargs,
-                )
-                for vmi in vmis.get("items", []):
-                    if regex_name is None:
-                        vmis_list.append(vmi)
-                    else:
-                        vmi_name = vmi.get("metadata", {}).get("name", "")
-                        if re.match(regex_name, vmi_name):
+
+            if namespace == ".*":
+                # Single cluster-wide call instead of one call per namespace
+                continue_token = None
+                while True:
+                    page_kwargs = {**kwargs, "limit": 500}
+                    if continue_token:
+                        page_kwargs["_continue"] = continue_token
+                    vmis = (
+                        self.custom_object_client.list_cluster_custom_object(
+                            group="kubevirt.io",
+                            version="v1",
+                            plural="virtualmachineinstances",
+                            **page_kwargs,
+                        )
+                    )
+                    for vmi in vmis.get("items", []):
+                        if regex_name is None:
                             vmis_list.append(vmi)
+                        else:
+                            vmi_name = vmi.get("metadata", {}).get("name", "")
+                            if re.match(regex_name, vmi_name):
+                                vmis_list.append(vmi)
+                    continue_token = vmis.get("metadata", {}).get("continue")
+                    if not continue_token:
+                        break
+            else:
+                namespaces = self.list_namespaces_by_regex(namespace)
+                client = self.custom_object_client
+                for ns in namespaces:
+                    vmis = client.list_namespaced_custom_object(
+                        group="kubevirt.io",
+                        version="v1",
+                        namespace=ns,
+                        plural="virtualmachineinstances",
+                        **kwargs,
+                    )
+                    for vmi in vmis.get("items", []):
+                        if regex_name is None:
+                            vmis_list.append(vmi)
+                        else:
+                            vmi_name = vmi.get("metadata", {}).get("name", "")
+                            if re.match(regex_name, vmi_name):
+                                vmis_list.append(vmi)
         except ApiException as e:
             if e.status == 404:
                 logging.warning(
@@ -2514,7 +2542,6 @@ class KrknKubernetes:
         ).rstrip()
         exists = exists if exists else "False"
         return exists == "True"
-
 
     def get_node_cpu_count(self, node_name: str) -> int:
         """

--- a/src/krkn_lib/models/telemetry/models.py
+++ b/src/krkn_lib/models/telemetry/models.py
@@ -7,7 +7,12 @@ from datetime import datetime, timezone
 
 import yaml
 
-from krkn_lib.models.k8s import AffectedNode, PodsStatus, VmisStatus, ResiliencyReport
+from krkn_lib.models.k8s import (
+    AffectedNode,
+    PodsStatus,
+    VmisStatus,
+    ResiliencyReport,
+)
 
 relevant_event_reasons: frozenset[str] = frozenset(
     [

--- a/src/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py
+++ b/src/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py
@@ -107,10 +107,16 @@ class KrknTelemetryKubernetes:
         kube = self.__kubecli
         calls = {
             "get_all_kubernetes_object_count": lambda: (
-                kube.get_all_kubernetes_object_count([
-                    "Deployment", "Pod", "Secret",
-                    "ConfigMap", "Build", "Route",
-                ])
+                kube.get_all_kubernetes_object_count(
+                    [
+                        "Deployment",
+                        "Pod",
+                        "Secret",
+                        "ConfigMap",
+                        "Build",
+                        "Route",
+                    ]
+                )
             ),
             "get_nodes_infos": kube.get_nodes_infos,
             "get_version": kube.get_version,
@@ -149,7 +155,9 @@ class KrknTelemetryKubernetes:
             get_result("get_all_kubernetes_object_count") or {}
         )
         nodes_result = get_result("get_nodes_infos")
-        node_infos, taints = nodes_result if nodes_result is not None else ([], [])
+        node_infos, taints = (
+            nodes_result if nodes_result is not None else ([], [])
+        )
         chaos_telemetry.node_summary_infos = node_infos
         cluster_version = get_result("get_version") or ""
         chaos_telemetry.cluster_version = cluster_version

--- a/src/krkn_lib/telemetry/ocp/krkn_telemetry_openshift.py
+++ b/src/krkn_lib/telemetry/ocp/krkn_telemetry_openshift.py
@@ -1,6 +1,5 @@
 import concurrent.futures
 import datetime
-import json
 import logging
 import os
 import threading
@@ -291,33 +290,25 @@ class KrknTelemetryOpenshift(KrknTelemetryKubernetes):
         self.safe_logger.info("ocp logs successfully uploaded")
 
     def get_vm_number(self) -> int:
-        api_client = self.__ocpcli.api_client
-        if api_client:
-            try:
-                path_params: dict[str, str] = {}
-                query_params: list[str] = []
-                header_params: dict[str, str] = {}
-                auth_settings = ["BearerToken"]
-                header_params["Accept"] = api_client.select_header_accept(
-                    ["application/json"]
+        try:
+            count = 0
+            continue_token = None
+            client = self.__ocpcli.custom_object_client
+            while True:
+                kwargs = {"limit": 500}
+                if continue_token:
+                    kwargs["_continue"] = continue_token
+                result = client.list_cluster_custom_object(
+                    group="kubevirt.io",
+                    version="v1",
+                    plural="virtualmachineinstances",
+                    **kwargs,
                 )
-
-                path = "/apis/kubevirt.io/v1/virtualmachineinstances"
-                data = api_client.call_api(
-                    path,
-                    "GET",
-                    path_params,
-                    query_params,
-                    header_params,
-                    response_type="str",
-                    auth_settings=auth_settings,
-                )
-                if data[1] != 200:
-                    return 0
-
-                json_obj = json.loads(data[0])
-                return len(json_obj["items"])
-            except Exception:
-                logging.info("failed to parse virtualmachines API")
-                return 0
-        return 0
+                count += len(result["items"])
+                continue_token = result.get("metadata", {}).get("continue")
+                if not continue_token:
+                    break
+            return count
+        except Exception as e:
+            logging.info(f"failed to get virtualmachines: {e}")
+            return 0

--- a/src/krkn_lib/tests/test_krkn_elastic_models.py
+++ b/src/krkn_lib/tests/test_krkn_elastic_models.py
@@ -105,7 +105,8 @@ class TestKrknElasticModels(BaseTest):
             len(elastic_telemetry.scenarios[0].affected_vmis.unrecovered), 1
         )
         self.assertEqual(
-            elastic_telemetry.scenarios[0].affected_vmis.error, "some vmi error"
+            elastic_telemetry.scenarios[0].affected_vmis.error,
+            "some vmi error",
         )
 
         # scenarios -> affected_vmis -> recovered

--- a/src/krkn_lib/tests/test_krkn_telemetry_openshift.py
+++ b/src/krkn_lib/tests/test_krkn_telemetry_openshift.py
@@ -1,0 +1,80 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from krkn_lib.ocp import KrknOpenshift
+from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+from krkn_lib.utils.safe_logger import SafeLogger
+
+
+def _make_telemetry():
+    mock_logger = Mock(spec=SafeLogger)
+    mock_ocpcli = Mock(spec=KrknOpenshift)
+    return KrknTelemetryOpenshift(
+        safe_logger=mock_logger,
+        lib_openshift=mock_ocpcli,
+    ), mock_ocpcli
+
+
+def _cluster_response(items, continue_token=None):
+    resp = {"items": items, "metadata": {}}
+    if continue_token:
+        resp["metadata"]["continue"] = continue_token
+    return resp
+
+
+class TestGetVmNumber(unittest.TestCase):
+
+    def test_returns_correct_count(self):
+        """Returns count from a single-page cluster-wide response."""
+        telemetry, mock_ocpcli = _make_telemetry()
+        client = mock_ocpcli.custom_object_client
+        client.list_cluster_custom_object.return_value = (
+            _cluster_response([{}, {}, {}])
+        )
+        self.assertEqual(telemetry.get_vm_number(), 3)
+        client.list_cluster_custom_object.assert_called_once_with(
+            group="kubevirt.io",
+            version="v1",
+            plural="virtualmachineinstances",
+            limit=500,
+        )
+
+    def test_paginates_across_pages(self):
+        """Follows continue token and sums items across pages."""
+        telemetry, mock_ocpcli = _make_telemetry()
+        client = mock_ocpcli.custom_object_client
+        client.list_cluster_custom_object.side_effect = [
+            _cluster_response([{}, {}], continue_token="tok1"),
+            _cluster_response([{}]),
+        ]
+        self.assertEqual(telemetry.get_vm_number(), 3)
+        self.assertEqual(
+            client.list_cluster_custom_object.call_count, 2
+        )
+
+    def test_empty_vmi_list_returns_zero(self):
+        """Empty cluster returns 0."""
+        telemetry, mock_ocpcli = _make_telemetry()
+        client = mock_ocpcli.custom_object_client
+        client.list_cluster_custom_object.return_value = (
+            _cluster_response([])
+        )
+        self.assertEqual(telemetry.get_vm_number(), 0)
+
+    @patch("krkn_lib.telemetry.ocp.krkn_telemetry_openshift.logging")
+    def test_exception_returns_zero_and_logs(self, mock_logging):
+        """Exception returns 0 and logs the error message."""
+        telemetry, mock_ocpcli = _make_telemetry()
+        client = mock_ocpcli.custom_object_client
+        client.list_cluster_custom_object.side_effect = (
+            Exception("connection refused")
+        )
+        self.assertEqual(telemetry.get_vm_number(), 0)
+        mock_logging.info.assert_called_once()
+        self.assertIn(
+            "connection refused", mock_logging.info.call_args[0][0]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Description  
- get_vmis: add fast path for namespace=".*" using list_cluster_custom_object instead of one namespaced call per namespace; includes limit/continue pagination so counts over 500 VMIs are not missed
- get_vm_number: replace raw call_api with list_cluster_custom_object directly, reducing N+1 namespace round trips to a single paginated cluster-wide call
- add unit tests for get_vm_number covering count, pagination, and error cases

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  