### PR TITLE
Dyn client don't reinitalize

### DIFF
--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -78,8 +78,12 @@ class KrknKubernetes:
         return client.NetworkingV1Api(self.api_client)
 
     @property
-    def dyn_client(cls) -> DynamicClient:
-        return DynamicClient(cls.api_client)
+    def dyn_client(self) -> DynamicClient:
+        if self._dyn_client is None:
+            with self._dyn_client_lock:
+                if self._dyn_client is None:
+                    self._dyn_client = DynamicClient(self.api_client)
+        return self._dyn_client
 
     @property
     def custom_object_client(cls) -> client.CustomObjectsApi:
@@ -110,6 +114,8 @@ class KrknKubernetes:
             action="ignore", message="unclosed", category=ResourceWarning
         )
 
+        self._dyn_client = None
+        self._dyn_client_lock = threading.Lock()
         self.request_chunk_size = request_chunk_size
 
         if kubeconfig_string is not None:
@@ -2504,27 +2510,59 @@ class KrknKubernetes:
     def get_all_kubernetes_object_count(
         self, objects: list[str]
     ) -> dict[str, int]:
+        # Use typed API clients so we never touch DynamicClient/LazyDiscoverer.
+        # LazyDiscoverer scans every API group on first call — on OCP with
+        # hundreds of CRDs that takes > 60s and blows the telemetry timeout.
+        # Typed clients go directly to the specific endpoint with no discovery.
+        # _continue is the correct kwarg name for the typed clients; they remap
+        # it to ?continue=… in the query string internally.
+        kind_listers = {
+            "Pod": self.cli.list_pod_for_all_namespaces,
+            "Secret": self.cli.list_secret_for_all_namespaces,
+            "ConfigMap": self.cli.list_config_map_for_all_namespaces,
+            "Namespace": self.cli.list_namespace,
+            "ServiceAccount": self.cli.list_service_account_for_all_namespaces,
+            "Deployment": self.apps_api.list_deployment_for_all_namespaces,
+            "ReplicaSet": self.apps_api.list_replica_set_for_all_namespaces,
+            "DaemonSet": self.apps_api.list_daemon_set_for_all_namespaces,
+            "StatefulSet": self.apps_api.list_stateful_set_for_all_namespaces,
+        }
+
         def count_kind(kind):
+            lister = kind_listers.get(kind)
+            if lister is None:
+                logging.warning(
+                    "get_all_kubernetes_object_count: no typed lister for %s,"
+                    " skipping",
+                    kind,
+                )
+                return kind, None
             try:
-                resource = self.dyn_client.resources.get(kind=kind)
                 count = 0
                 continue_token = None
                 while True:
                     kwargs = {"limit": 500}
                     if continue_token:
                         kwargs["_continue"] = continue_token
-                    resp = resource.get(**kwargs)
+                    resp = lister(**kwargs)
                     count += len(resp.items)
-                    continue_token = resp.metadata._continue
+                    continue_token = resp.metadata._continue or None
                     if not continue_token:
                         break
                 return kind, count
-            except Exception:
+            except Exception as e:
+                logging.warning(
+                    "get_all_kubernetes_object_count: skipping %s: %s",
+                    kind,
+                    e,
+                )
                 return kind, None
 
         result = {}
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = {executor.submit(count_kind, k): k for k in objects}
+            futures = {
+                executor.submit(count_kind, k): k for k in objects
+            }
             for future in concurrent.futures.as_completed(futures):
                 kind, count = future.result()
                 if count is not None:

--- a/src/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py
+++ b/src/krkn_lib/telemetry/k8s/krkn_telemetry_kubernetes.py
@@ -113,8 +113,6 @@ class KrknTelemetryKubernetes:
                         "Pod",
                         "Secret",
                         "ConfigMap",
-                        "Build",
-                        "Route",
                     ]
                 )
             ),

--- a/src/krkn_lib/telemetry/ocp/krkn_telemetry_openshift.py
+++ b/src/krkn_lib/telemetry/ocp/krkn_telemetry_openshift.py
@@ -98,6 +98,8 @@ class KrknTelemetryOpenshift(KrknTelemetryKubernetes):
             "get_clusterversion_string": ocp.get_clusterversion_string,
             "get_cluster_network_plugins": ocp.get_cluster_network_plugins,
             "get_vm_number": self.get_vm_number,
+            "get_build_count": self.get_build_count,
+            "get_route_count": self.get_route_count,
         }
 
         executor = concurrent.futures.ThreadPoolExecutor(
@@ -142,6 +144,10 @@ class KrknTelemetryOpenshift(KrknTelemetryKubernetes):
             chaos_telemetry.kubernetes_objects_count[
                 "VirtualMachineInstance"
             ] = vm_number
+        build_count = get_result("get_build_count") or 0
+        chaos_telemetry.kubernetes_objects_count["Build"] = build_count
+        route_count = get_result("get_route_count") or 0
+        chaos_telemetry.kubernetes_objects_count["Route"] = route_count
 
     def put_ocp_logs(
         self,
@@ -289,26 +295,51 @@ class KrknTelemetryOpenshift(KrknTelemetryKubernetes):
         queue.join()
         self.safe_logger.info("ocp logs successfully uploaded")
 
+    def _count_custom_objects(
+        self, group: str, version: str, plural: str
+    ) -> int:
+        count = 0
+        continue_token = None
+        client = self.__ocpcli.custom_object_client
+        while True:
+            kwargs = {"limit": 500}
+            if continue_token:
+                kwargs["_continue"] = continue_token
+            result = client.list_cluster_custom_object(
+                group=group,
+                version=version,
+                plural=plural,
+                **kwargs,
+            )
+            count += len(result["items"])
+            continue_token = result.get("metadata", {}).get("continue")
+            if not continue_token:
+                break
+        return count
+
     def get_vm_number(self) -> int:
         try:
-            count = 0
-            continue_token = None
-            client = self.__ocpcli.custom_object_client
-            while True:
-                kwargs = {"limit": 500}
-                if continue_token:
-                    kwargs["_continue"] = continue_token
-                result = client.list_cluster_custom_object(
-                    group="kubevirt.io",
-                    version="v1",
-                    plural="virtualmachineinstances",
-                    **kwargs,
-                )
-                count += len(result["items"])
-                continue_token = result.get("metadata", {}).get("continue")
-                if not continue_token:
-                    break
-            return count
+            return self._count_custom_objects(
+                "kubevirt.io", "v1", "virtualmachineinstances"
+            )
         except Exception as e:
             logging.info(f"failed to get virtualmachines: {e}")
+            return 0
+
+    def get_build_count(self) -> int:
+        try:
+            return self._count_custom_objects(
+                "build.openshift.io", "v1", "builds"
+            )
+        except Exception as e:
+            logging.info(f"failed to get builds: {e}")
+            return 0
+
+    def get_route_count(self) -> int:
+        try:
+            return self._count_custom_objects(
+                "route.openshift.io", "v1", "routes"
+            )
+        except Exception as e:
+            logging.info(f"failed to get routes: {e}")
             return 0

--- a/src/krkn_lib/tests/test_krkn_kubernetes_get.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_get.py
@@ -1,3 +1,6 @@
+# Run: poetry run python3 -m coverage run -a -m unittest src/krkn_lib/tests/test_krkn_kubernetes_get.py -v
+# Requires: KUBECONFIG pointing to a running Kubernetes cluster
+
 import logging
 import os
 import random
@@ -203,6 +206,7 @@ class KrknKubernetesTestsGet(BaseTest):
         self.assertIn("ConfigMap", objs)
         self.assertNotIn("Unknown", objs)
         self.assertGreater(objs["Namespace"], 0)
+        self.assertGreater(objs["ConfigMap"], 0)
 
     def test_get_nodes_infos(self):
         telemetry = ChaosRunTelemetry()
@@ -330,6 +334,7 @@ class KrknKubernetesTestsGet(BaseTest):
         """Test FIPS detection returns a boolean."""
         result = self.lib_k8s.is_fips_enabled()
         self.assertIsInstance(result, bool)
+        self.assertFalse(result)
 
     def test_is_etcd_encryption_enabled(self):
         """Test etcd encryption detection returns a boolean."""
@@ -342,6 +347,7 @@ class KrknKubernetesTestsGet(BaseTest):
         """Test IPsec detection returns a boolean."""
         result = self.lib_k8s.is_ipsec_enabled()
         self.assertIsInstance(result, bool)
+        self.assertFalse(result)
 
 
 if __name__ == "__main__":

--- a/src/krkn_lib/tests/test_krkn_telemetry_openshift.py
+++ b/src/krkn_lib/tests/test_krkn_telemetry_openshift.py
@@ -76,5 +76,110 @@ class TestGetVmNumber(unittest.TestCase):
         )
 
 
+class TestGetBuildCount(unittest.TestCase):
+
+    def test_returns_correct_count(self):
+        """Returns count from a single-page cluster-wide response."""
+        telemetry, mock_ocpcli = _make_telemetry()
+        client = mock_ocpcli.custom_object_client
+        client.list_cluster_custom_object.return_value = (
+            _cluster_response([{}, {}])
+        )
+        self.assertEqual(telemetry.get_build_count(), 2)
+        client.list_cluster_custom_object.assert_called_once_with(
+            group="build.openshift.io",
+            version="v1",
+            plural="builds",
+            limit=500,
+        )
+
+    def test_paginates_across_pages(self):
+        """Follows continue token and sums items across pages."""
+        telemetry, mock_ocpcli = _make_telemetry()
+        client = mock_ocpcli.custom_object_client
+        client.list_cluster_custom_object.side_effect = [
+            _cluster_response([{}, {}], continue_token="tok1"),
+            _cluster_response([{}, {}], continue_token="tok2"),
+            _cluster_response([{}]),
+        ]
+        self.assertEqual(telemetry.get_build_count(), 5)
+        self.assertEqual(client.list_cluster_custom_object.call_count, 3)
+
+    def test_empty_build_list_returns_zero(self):
+        """Empty cluster returns 0."""
+        telemetry, mock_ocpcli = _make_telemetry()
+        client = mock_ocpcli.custom_object_client
+        client.list_cluster_custom_object.return_value = (
+            _cluster_response([])
+        )
+        self.assertEqual(telemetry.get_build_count(), 0)
+
+    @patch("krkn_lib.telemetry.ocp.krkn_telemetry_openshift.logging")
+    def test_exception_returns_zero_and_logs(self, mock_logging):
+        """Exception returns 0 and logs the error message."""
+        telemetry, mock_ocpcli = _make_telemetry()
+        client = mock_ocpcli.custom_object_client
+        client.list_cluster_custom_object.side_effect = (
+            Exception("builds api not found")
+        )
+        self.assertEqual(telemetry.get_build_count(), 0)
+        mock_logging.info.assert_called_once()
+        self.assertIn(
+            "builds api not found", mock_logging.info.call_args[0][0]
+        )
+
+
+class TestGetRouteCount(unittest.TestCase):
+
+    def test_returns_correct_count(self):
+        """Returns count from a single-page cluster-wide response."""
+        telemetry, mock_ocpcli = _make_telemetry()
+        client = mock_ocpcli.custom_object_client
+        client.list_cluster_custom_object.return_value = (
+            _cluster_response([{}, {}, {}, {}])
+        )
+        self.assertEqual(telemetry.get_route_count(), 4)
+        client.list_cluster_custom_object.assert_called_once_with(
+            group="route.openshift.io",
+            version="v1",
+            plural="routes",
+            limit=500,
+        )
+
+    def test_paginates_across_pages(self):
+        """Follows continue token and sums items across pages."""
+        telemetry, mock_ocpcli = _make_telemetry()
+        client = mock_ocpcli.custom_object_client
+        client.list_cluster_custom_object.side_effect = [
+            _cluster_response([{}, {}], continue_token="tok1"),
+            _cluster_response([{}]),
+        ]
+        self.assertEqual(telemetry.get_route_count(), 3)
+        self.assertEqual(client.list_cluster_custom_object.call_count, 2)
+
+    def test_empty_route_list_returns_zero(self):
+        """Empty cluster returns 0."""
+        telemetry, mock_ocpcli = _make_telemetry()
+        client = mock_ocpcli.custom_object_client
+        client.list_cluster_custom_object.return_value = (
+            _cluster_response([])
+        )
+        self.assertEqual(telemetry.get_route_count(), 0)
+
+    @patch("krkn_lib.telemetry.ocp.krkn_telemetry_openshift.logging")
+    def test_exception_returns_zero_and_logs(self, mock_logging):
+        """Exception returns 0 and logs the error message."""
+        telemetry, mock_ocpcli = _make_telemetry()
+        client = mock_ocpcli.custom_object_client
+        client.list_cluster_custom_object.side_effect = (
+            Exception("routes api not found")
+        )
+        self.assertEqual(telemetry.get_route_count(), 0)
+        mock_logging.info.assert_called_once()
+        self.assertIn(
+            "routes api not found", mock_logging.info.call_args[0][0]
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description  
Root cause: dyn_client was a @property that called DynamicClient(self.api_client) on every access, creating a new instance each time. All 6 threads in get_all_kubernetes_object_count simultaneously constructed their own DynamicClient, each trying to read/write the same temp cache file (osrcp-<md5>.json) — resulting in mid-write JSON corruption and the Expecting ':' delimiter errors.

Fix: _dyn_client = None initialized in __init__, and the property now lazily creates it once and caches it. All threads share the same already-initialized instance, so resources.get(kind) is just a dict lookup with no file I/O.

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  