### PR TITLE
feat(k8s): add deploy_io_throttle_pod helper for storage I/O throttle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ cryptography = ">=46.0.7"
 pyasn1 = ">=0.6.3"
 pygments = ">=2.20.0"
 pillow = ">=12.2.0"
+jinja2 = "^3.1.2"
 
 [tool.poetry.group.test.dependencies]
-jinja2 = "^3.1.2"
 boto3 = "^1.28.12"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ cryptography = ">=46.0.7"
 pyasn1 = ">=0.6.3"
 pygments = ">=2.20.0"
 pillow = ">=12.2.0"
-jinja2 = "^3.1.2"
 
 [tool.poetry.group.test.dependencies]
+jinja2 = "^3.1.2"
 boto3 = "^1.28.12"
 
 [tool.black]

--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -8,6 +8,7 @@ import re
 import tempfile
 import threading
 import time
+import uuid
 import warnings
 from queue import Queue
 from typing import Any, Dict, List, Optional
@@ -1237,7 +1238,7 @@ class KrknKubernetes:
         file_loader = PackageLoader("krkn_lib.k8s", "templates")
         env = Environment(loader=file_loader, autoescape=True)
         template = env.get_template("io_throttle_pod.j2")
-        pod_suffix = str(random.randint(10000, 99999))
+        pod_suffix = uuid.uuid4().hex[:10]
         pod_body = yaml.safe_load(
             template.render(
                 pod_suffix=pod_suffix,
@@ -1346,26 +1347,35 @@ class KrknKubernetes:
         :param namespace: namespace where the pod is created
         :param timeout: request timeout
         """
+        pod_stat = None
+        pod_name = body["metadata"]["name"]
         try:
-            pod_stat = None
             pod_stat = self.cli.create_namespaced_pod(
                 body=body, namespace=namespace
             )
             end_time = time.time() + timeout
             while True:
                 pod_stat = self.cli.read_namespaced_pod(
-                    name=body["metadata"]["name"], namespace=namespace
+                    name=pod_name, namespace=namespace
                 )
                 if pod_stat.status.phase == "Running":
                     break
                 if time.time() > end_time:
                     raise Exception("Starting pod failed")
                 time.sleep(1)
+        except ApiException as e:
+            logging.error("Pod creation failed %s", str(e))
+            if e.status == 409:
+                raise e
+            if pod_stat is not None:
+                self.delete_pod(pod_name, namespace)
+            raise e
         except Exception as e:
             logging.error("Pod creation failed %s", str(e))
-            if pod_stat:
-                logging.error(pod_stat.status.container_statuses)
-            self.delete_pod(body["metadata"]["name"], namespace)
+            if pod_stat is not None:
+                if pod_stat.status and pod_stat.status.container_statuses:
+                    logging.error(pod_stat.status.container_statuses)
+                self.delete_pod(pod_name, namespace)
             raise e
 
     def read_pod(self, name: str, namespace: str = "default") -> client.V1Pod:

--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -1216,6 +1216,39 @@ class KrknKubernetes:
 
         return ret
 
+    def deploy_io_throttle_pod(
+        self,
+        node_name: str,
+        image: str,
+        namespace: str = "default",
+        timeout: int = 300,
+    ) -> str:
+        """
+        Deploy a privileged pod on a node for I/O throttling via cgroup.
+
+        The pod mounts the host root filesystem at /host.
+
+        :param node_name: target node
+        :param image: container image to use
+        :param namespace: namespace for the pod
+        :param timeout: seconds to wait for pod readiness
+        :return: the generated pod name
+        """
+        file_loader = PackageLoader("krkn_lib.k8s", "templates")
+        env = Environment(loader=file_loader, autoescape=True)
+        template = env.get_template("io_throttle_pod.j2")
+        pod_suffix = str(random.randint(10000, 99999))
+        pod_body = yaml.safe_load(
+            template.render(
+                pod_suffix=pod_suffix,
+                nodename=node_name,
+                image=image,
+            )
+        )
+        pod_name = "io-throttle-%s" % pod_suffix
+        self.create_pod(pod_body, namespace, timeout)
+        return pod_name
+
     def exec_command_on_node(
         self,
         node_name: str,

--- a/src/krkn_lib/k8s/templates/io_throttle_pod.j2
+++ b/src/krkn_lib/k8s/templates/io_throttle_pod.j2
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: io-throttle-{{pod_suffix}}
+spec:
+  nodeName: {{nodename}}
+  containers:
+  - name: io-throttle
+    image: {{image}}
+    command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: host-root
+      mountPath: /host
+  volumes:
+  - name: host-root
+    hostPath:
+      path: /
+  restartPolicy: Never

--- a/src/krkn_lib/tests/test_deploy_io_throttle_pod.py
+++ b/src/krkn_lib/tests/test_deploy_io_throttle_pod.py
@@ -1,0 +1,69 @@
+"""Unit tests for deploy_io_throttle_pod and create_pod conflict handling."""
+
+import unittest
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from kubernetes.client import ApiException
+
+from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
+
+
+class TestDeployIoThrottlePod(unittest.TestCase):
+    def setUp(self):
+        self.lib_k8s = KrknKubernetes.__new__(KrknKubernetes)
+
+    @patch(
+        "krkn_lib.k8s.krkn_kubernetes.uuid.uuid4",
+        return_value=MagicMock(hex="a1b2c3d4e5f678901234567890abcdef"),
+    )
+    def test_deploy_uses_uuid_suffix(self, _mock_uuid):
+        self.lib_k8s.create_pod = MagicMock()
+        pod_name = self.lib_k8s.deploy_io_throttle_pod(
+            "worker-1", "quay.io/example/tools:latest", "default", 1
+        )
+        self.assertEqual(pod_name, "io-throttle-a1b2c3d4e5")
+        create_body = self.lib_k8s.create_pod.call_args[0][0]
+        self.assertEqual(
+            create_body["metadata"]["name"], "io-throttle-a1b2c3d4e5"
+        )
+        self.lib_k8s.create_pod.assert_called_once()
+
+
+class TestCreatePodConflictHandling(unittest.TestCase):
+    def setUp(self):
+        self.lib_k8s = KrknKubernetes.__new__(KrknKubernetes)
+        self.mock_cli = MagicMock()
+        self.cli_patcher = patch.object(
+            KrknKubernetes,
+            "cli",
+            new_callable=PropertyMock,
+            return_value=self.mock_cli,
+        )
+        self.cli_patcher.start()
+        self.addCleanup(self.cli_patcher.stop)
+        self.lib_k8s.delete_pod = MagicMock()
+
+    def test_create_pod_does_not_delete_on_already_exists(self):
+        conflict = ApiException(status=409, reason="AlreadyExists")
+        self.mock_cli.create_namespaced_pod.side_effect = conflict
+        body = {"metadata": {"name": "io-throttle-existing"}}
+
+        with self.assertRaises(ApiException):
+            self.lib_k8s.create_pod(body, "default", 1)
+
+        self.lib_k8s.delete_pod.assert_not_called()
+
+    @patch("krkn_lib.k8s.krkn_kubernetes.time.sleep")
+    def test_create_pod_deletes_only_when_pod_was_created(self, _mock_sleep):
+        created = MagicMock()
+        self.mock_cli.create_namespaced_pod.return_value = created
+        self.mock_cli.read_namespaced_pod.side_effect = Exception("read failed")
+
+        with self.assertRaises(Exception):
+            self.lib_k8s.create_pod(
+                {"metadata": {"name": "io-throttle-new"}}, "default", 1
+            )
+
+        self.lib_k8s.delete_pod.assert_called_once_with(
+            "io-throttle-new", "default"
+        )

--- a/src/krkn_lib/tests/test_io_throttle_pod_template.py
+++ b/src/krkn_lib/tests/test_io_throttle_pod_template.py
@@ -1,0 +1,28 @@
+"""Unit tests for io_throttle_pod Jinja template (no cluster required)."""
+
+import unittest
+
+import yaml
+from jinja2 import Environment, PackageLoader
+
+
+class TestIoThrottlePodTemplate(unittest.TestCase):
+    def test_template_renders_valid_pod_manifest(self):
+        env = Environment(
+            loader=PackageLoader("krkn_lib.k8s", "templates"),
+            autoescape=True,
+        )
+        template = env.get_template("io_throttle_pod.j2")
+        body = yaml.safe_load(
+            template.render(
+                pod_suffix="12345",
+                nodename="worker-1",
+                image="quay.io/example/tools:latest",
+            )
+        )
+        self.assertEqual(body["kind"], "Pod")
+        self.assertEqual(body["metadata"]["name"], "io-throttle-12345")
+        self.assertEqual(body["spec"]["nodeName"], "worker-1")
+        self.assertTrue(
+            body["spec"]["containers"][0]["securityContext"]["privileged"]
+        )


### PR DESCRIPTION
## Summary

- Add `KrknKubernetes.deploy_io_throttle_pod()` to create the privileged helper pod used for cgroup-based storage I/O throttling (host root mounted at `/host`), using the same Jinja + `PackageLoader("krkn_lib.k8s", "templates")` pattern as other k8s helpers.
- Add `src/krkn_lib/k8s/templates/io_throttle_pod.j2` (pod spec previously maintained in krkn).
- Add `test_io_throttle_pod_template.py`: no-cluster unit test that the template renders valid pod YAML via `PackageLoader`.

## Motivation

Centralizes the helper pod manifest in krkn-lib so scenario plugins (e.g. storage throttle in krkn) do not ship duplicate `.j2` files or duplicate Jinja wiring.

## Testing

- `PYTHONPATH=src python -m unittest krkn_lib.tests.test_io_throttle_pod_template -v`

## Follow-up (krkn)

After this is released and version-pinned in krkn, switch `StorageThrottleScenarioPlugin` to call `deploy_io_throttle_pod()` and remove the in-repo `privileged_pod.j2` (separate PR).