### PR TITLE
Add DCO signoff check workflow

### DIFF
--- a/.github/workflows/needs-dco.yml
+++ b/.github/workflows/needs-dco.yml
@@ -1,0 +1,16 @@
+name: Needs DCO Signoff
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  dco:
+    uses: krkn-chaos/actions/.github/workflows/needs-dco.yml@main


### PR DESCRIPTION
## Summary
- Adds reusable DCO signoff check workflow that calls `krkn-chaos/actions/.github/workflows/needs-dco.yml@main`
- Automatically labels PRs with `needs-dco` and posts fix instructions if any commits are missing a `Signed-off-by` line
- Label and comment are removed automatically once all commits are signed off

## Test plan
- [ ] Open a PR with an unsigned commit and verify the `needs-dco` label and comment appear
- [ ] Push a signed-off commit and verify the label and comment are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)