### PR TITLE
refactor: move needs-rebase to reusable workflow in krkn-chaos/actions

### DIFF
--- a/.github/workflows/needs-rebase.yml
+++ b/.github/workflows/needs-rebase.yml
@@ -1,0 +1,16 @@
+name: Needs Rebase
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  rebase:
+    uses: krkn-chaos/actions/.github/workflows/needs-rebase.yml@main


### PR DESCRIPTION
## Summary
- Adds `needs-rebase.yml` as a thin caller to the reusable workflow in `krkn-chaos/actions`
- Automatically labels PRs with `needs-rebase` and posts rebase instructions when merge conflicts are detected; cleans up when resolved

## Test plan
- [ ] Verify the `Needs Rebase` check appears on new PRs
- [ ] Verify the `needs-rebase` label and comment are added/removed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)