### PR TITLE
add stale issue and PR management workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,14 @@
+name: Manage Stale Issues and Pull Requests
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    uses: krkn-chaos/actions/.github/workflows/stale.yml@main


### PR DESCRIPTION
## Summary
- Adds stale workflow calling the reusable workflow in `krkn-chaos/actions`
- Marks issues stale after 60 days, closes after 14 more days
- Marks PRs stale after 90 days, closes after 14 more days
- Exempt labels: `bug`, `enhancement`, `good first issue` (issues) and `pending discussions`, `hold` (PRs)
- Stale label/close removed automatically when issue or PR is updated

## Test plan
- [ ] Trigger via `workflow_dispatch` and verify stale labels are applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)