### PR TITLE
Quay image instead of docker

### DIFF
--- a/src/krkn_lib/k8s/templates/node_exec_pod.j2
+++ b/src/krkn_lib/k8s/templates/node_exec_pod.j2
@@ -7,7 +7,7 @@ spec:
   nodeName: {{nodename}}
   containers:
   - name: fedtools
-    image: docker.io/fedora/tools
+    image: quay.io/krkn-chaos/krkn-lib:fedtools
     command:
     - /bin/sh
     - -c

--- a/src/testdata/job.j2
+++ b/src/testdata/job.j2
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: pi
-        image: docker.io/fedora/tools
+        image: quay.io/krkn-chaos/krkn-lib:fedtools
         command: ["sleep","10"]
       restartPolicy: Never
   backoffLimit: 4


### PR DESCRIPTION
## Description  
Updating images to quay instead of docker, hitting some new errors

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  

```
======================================================================
FAIL: test_command_on_node (test_krkn_kubernetes_exec.KrknKubernetesTestsExec.test_command_on_node)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/krkn-lib/krkn-lib/src/krkn_lib/tests/test_krkn_kubernetes_exec.py", line 115, in test_command_on_node
    response = self.lib_k8s.exec_command_on_node(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/krkn-lib/krkn-lib/src/krkn_lib/k8s/krkn_kubernetes.py", line 1298, in exec_command_on_node
    raise e
  File "/home/runner/work/krkn-lib/krkn-lib/src/krkn_lib/k8s/krkn_kubernetes.py", line 1292, in exec_command_on_node
    self.create_pod(pod_body, exec_pod_namespace, 500)
  File "/home/runner/work/krkn-lib/krkn-lib/src/krkn_lib/k8s/krkn_kubernetes.py", line 1379, in create_pod
    raise e
  File "/home/runner/work/krkn-lib/krkn-lib/src/krkn_lib/k8s/krkn_kubernetes.py", line 1364, in create_pod
    raise Exception("Starting pod failed")
Exception: Starting pod failed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/krkn-lib/krkn-lib/src/krkn_lib/tests/test_krkn_kubernetes_exec.py", line 124, in test_command_on_node
    self.fail(f"exception on node command execution: {e}")
AssertionError: exception on node command execution: Starting pod failed

```