### PR TITLE
test: add branch coverage for krkn_kubernetes.py (#221)

### DIFF
--- a/src/krkn_lib/tests/test_krkn_kubernetes_delete.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_delete.py
@@ -1,10 +1,12 @@
 import logging
 import time
 import unittest
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from kubernetes.client import ApiException
 
 from krkn_lib.k8s import ApiRequestException
+from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
 from krkn_lib.tests import BaseTest
 
 
@@ -119,6 +121,121 @@ class KrknKubernetesTestsDelete(BaseTest):
                 )
                 break
         self.lib_k8s.delete_namespace(namespace)
+
+    def test_delete_deployment_already_deleted(self):
+        mock_apps = MagicMock()
+        mock_apps.delete_namespaced_deployment.side_effect = ApiException(status=404)
+        with patch.object(
+            KrknKubernetes,
+            "apps_api",
+            new_callable=PropertyMock,
+            return_value=mock_apps,
+        ):
+            self.lib_k8s.delete_deployment("name", "namespace")
+
+    def test_delete_deployment_api_error_raises(self):
+        mock_apps = MagicMock()
+        mock_apps.delete_namespaced_deployment.side_effect = ApiException(status=500)
+        with patch.object(
+            KrknKubernetes,
+            "apps_api",
+            new_callable=PropertyMock,
+            return_value=mock_apps,
+        ):
+            with self.assertRaises(ApiException):
+                self.lib_k8s.delete_deployment("name", "namespace")
+
+    def test_delete_daemonset_already_deleted(self):
+        mock_apps = MagicMock()
+        mock_apps.delete_namespaced_daemon_set.side_effect = ApiException(status=404)
+        with patch.object(
+            KrknKubernetes,
+            "apps_api",
+            new_callable=PropertyMock,
+            return_value=mock_apps,
+        ):
+            self.lib_k8s.delete_daemonset("name", "namespace")
+
+    def test_delete_daemonset_api_error_raises(self):
+        mock_apps = MagicMock()
+        mock_apps.delete_namespaced_daemon_set.side_effect = ApiException(status=500)
+        with patch.object(
+            KrknKubernetes,
+            "apps_api",
+            new_callable=PropertyMock,
+            return_value=mock_apps,
+        ):
+            with self.assertRaises(ApiException):
+                self.lib_k8s.delete_daemonset("name", "namespace")
+
+    def test_delete_statefulset_already_deleted(self):
+        mock_apps = MagicMock()
+        mock_apps.delete_namespaced_stateful_set.side_effect = ApiException(status=404)
+        with patch.object(
+            KrknKubernetes,
+            "apps_api",
+            new_callable=PropertyMock,
+            return_value=mock_apps,
+        ):
+            self.lib_k8s.delete_statefulset("name", "namespace")
+
+    def test_delete_statefulset_api_error_raises(self):
+        mock_apps = MagicMock()
+        mock_apps.delete_namespaced_stateful_set.side_effect = ApiException(status=500)
+        with patch.object(
+            KrknKubernetes,
+            "apps_api",
+            new_callable=PropertyMock,
+            return_value=mock_apps,
+        ):
+            with self.assertRaises(ApiException):
+                self.lib_k8s.delete_statefulset("name", "namespace")
+
+    def test_delete_replicaset_already_deleted(self):
+        mock_apps = MagicMock()
+        mock_apps.delete_namespaced_replica_set.side_effect = ApiException(status=404)
+        with patch.object(
+            KrknKubernetes,
+            "apps_api",
+            new_callable=PropertyMock,
+            return_value=mock_apps,
+        ):
+            self.lib_k8s.delete_replicaset("name", "namespace")
+
+    def test_delete_replicaset_api_error_raises(self):
+        mock_apps = MagicMock()
+        mock_apps.delete_namespaced_replica_set.side_effect = ApiException(status=500)
+        with patch.object(
+            KrknKubernetes,
+            "apps_api",
+            new_callable=PropertyMock,
+            return_value=mock_apps,
+        ):
+            with self.assertRaises(ApiException):
+                self.lib_k8s.delete_replicaset("name", "namespace")
+
+    def test_delete_services_already_deleted(self):
+        mock_cli = MagicMock()
+        mock_cli.delete_namespaced_service.side_effect = ApiException(status=404)
+        with patch.object(
+            KrknKubernetes,
+            "cli",
+            new_callable=PropertyMock,
+            return_value=mock_cli,
+        ):
+            self.lib_k8s.delete_services("name", "namespace")
+
+    def test_delete_services_api_error_raises(self):
+        mock_cli = MagicMock()
+        mock_cli.delete_namespaced_service.side_effect = ApiException(status=500)
+        with patch.object(
+            KrknKubernetes,
+            "cli",
+            new_callable=PropertyMock,
+            return_value=mock_cli,
+        ):
+            with self.assertRaises(ApiException):
+                self.lib_k8s.delete_services("name", "namespace")
 
 
 if __name__ == "__main__":

--- a/src/krkn_lib/tests/test_krkn_kubernetes_get.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_get.py
@@ -7,6 +7,7 @@ import random
 import re
 import time
 import unittest
+from unittest.mock import patch
 
 from kubernetes import config
 from kubernetes.client import ApiException
@@ -348,6 +349,33 @@ class KrknKubernetesTestsGet(BaseTest):
         result = self.lib_k8s.is_ipsec_enabled()
         self.assertIsInstance(result, bool)
         self.assertFalse(result)
+
+    def test_get_node_name_in_ready_nodes(self):
+        with patch.object(self.lib_k8s, "list_ready_nodes", side_effect=[["node-a", "node-b"]]):
+            result = self.lib_k8s.get_node("node-a", "label", 1)
+            self.assertEqual(result, ["node-a"])
+
+    def test_get_node_name_not_ready_falls_through(self):
+        with patch.object(self.lib_k8s, "list_ready_nodes", side_effect=[["node-b"], ["node-b"]]):
+            result = self.lib_k8s.get_node("node-a", "label", 1)
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result, ["node-b"])
+
+    def test_get_node_no_ready_nodes_raises(self):
+        with patch.object(self.lib_k8s, "list_ready_nodes", side_effect=[["node-b"], []]):
+            with self.assertRaises(Exception):
+                self.lib_k8s.get_node("node-a", "label", 1)
+
+    def test_get_node_kill_count_equals_total(self):
+        with patch.object(self.lib_k8s, "list_ready_nodes", side_effect=[["node-c"], ["node-a", "node-b"]]):
+            result = self.lib_k8s.get_node("node-a", "label", 2)
+            self.assertEqual(result, ["node-a", "node-b"])
+
+    def test_get_node_random_subset(self):
+        with patch.object(self.lib_k8s, "list_ready_nodes", side_effect=[["node-d"], ["node-a", "node-b", "node-c"]]):
+            result = self.lib_k8s.get_node("node-a", "label", 1)
+            self.assertEqual(len(result), 1)
+            self.assertIn(result[0], ["node-a", "node-b", "node-c"])
 
 
 if __name__ == "__main__":

--- a/src/krkn_lib/tests/test_krkn_kubernetes_list.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_list.py
@@ -1,5 +1,8 @@
 import logging
 import unittest
+from unittest.mock import MagicMock
+
+from kubernetes.client import ApiException
 
 from krkn_lib.tests import BaseTest
 
@@ -185,6 +188,22 @@ class KrknKubernetesTestsList(BaseTest):
         )
         self.assertGreater(len(nics), 0)
         self.assertTrue("eth0" in nics)
+
+    def test_list_continue_helper_api_exception(self):
+        mock_func = MagicMock(side_effect=ApiException(status=500))
+        result = self.lib_k8s.list_continue_helper(mock_func)
+        self.assertEqual(result, [])
+
+    def test_list_continue_helper_pagination(self):
+        page_1 = MagicMock()
+        page_1.metadata._continue = "token1"
+        page_2 = MagicMock()
+        page_2.metadata._continue = None
+        mock_func = MagicMock(side_effect=[page_1, page_2])
+
+        result = self.lib_k8s.list_continue_helper(mock_func)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result, [page_1, page_2])
 
 
 if __name__ == "__main__":

--- a/src/krkn_lib/tests/test_krkn_kubernetes_ocm.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_ocm.py
@@ -1,0 +1,101 @@
+import unittest
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from kubernetes.client import ApiException
+
+from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
+
+
+class TestKrknKubernetesOCM(unittest.TestCase):
+    def setUp(self):
+        """Set up mock objects for each test"""
+        self.mock_custom_client = MagicMock()
+
+        # Import and create instance with all mocks in place
+        with (
+            patch("kubernetes.config.load_kube_config"),
+            patch("kubernetes.client.CoreV1Api"),
+            patch("kubernetes.client.CustomObjectsApi"),
+            patch("kubernetes.client.AppsV1Api"),
+            patch("kubernetes.client.BatchV1Api"),
+            patch("kubernetes.client.ApiClient"),
+            patch("kubernetes.client.VersionApi"),
+            patch("kubernetes.client.NetworkingV1Api"),
+        ):
+            # Create KrknKubernetes instance with mocked dependencies
+            self.lib_k8s = KrknKubernetes(kubeconfig_path="dummy")
+
+        # Patch the custom_object_client property to return our mock
+        self.custom_client_patcher = patch.object(
+            type(self.lib_k8s),
+            "custom_object_client",
+            new_callable=PropertyMock,
+            return_value=self.mock_custom_client,
+        )
+        self.custom_client_patcher.start()
+
+    def tearDown(self):
+        """Clean up patches after each test"""
+        self.custom_client_patcher.stop()
+
+    def test_list_killable_managedclusters_api_exception(self):
+        self.mock_custom_client.list_cluster_custom_object.side_effect = ApiException(status=500)
+        with self.assertRaises(ApiException):
+            self.lib_k8s.list_killable_managedclusters()
+
+    def test_list_killable_managedclusters_empty(self):
+        self.mock_custom_client.list_cluster_custom_object.return_value = {"items": []}
+        result = self.lib_k8s.list_killable_managedclusters()
+        self.assertEqual(result, [])
+
+    def test_list_killable_managedclusters_available(self):
+        self.mock_custom_client.list_cluster_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {"name": "cluster-1"},
+                    "status": {
+                        "conditions": [
+                            {"reason": "ManagedClusterAvailable", "status": "True"}
+                        ]
+                    }
+                }
+            ]
+        }
+        result = self.lib_k8s.list_killable_managedclusters()
+        self.assertEqual(result, ["cluster-1"])
+
+    def test_list_killable_managedclusters_unavailable(self):
+        self.mock_custom_client.list_cluster_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {"name": "cluster-1"},
+                    "status": {
+                        "conditions": [
+                            {"reason": "ManagedClusterAvailable", "status": "False"}
+                        ]
+                    }
+                }
+            ]
+        }
+        result = self.lib_k8s.list_killable_managedclusters()
+        self.assertEqual(result, [])
+
+    def test_list_killable_managedclusters_no_available_condition(self):
+        self.mock_custom_client.list_cluster_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {"name": "cluster-1"},
+                    "status": {
+                        "conditions": [
+                            {"reason": "SomeOtherCondition", "status": "True"}
+                        ]
+                    }
+                }
+            ]
+        }
+        result = self.lib_k8s.list_killable_managedclusters()
+        self.assertEqual(result, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds unit tests covering previously untested branches in `krkn_kubernetes.py`.

This is a follow-up to #221. PR #287 addressed coverage for `krkn_telemetry_openshift.py`; this PR focuses on additional coverage in `krkn_kubernetes.py`.

## Changes

No production code modified.

Added coverage for:

- `get_node()`
- `list_continue_helper()`
- delete error-handling paths:
  - `delete_deployment()`
  - `delete_daemonset()`
  - `delete_statefulset()`
  - `delete_replicaset()`
  - `delete_services()`
- `list_killable_managedclusters()`

## Test Approach

- Uses `unittest.mock.patch`, `MagicMock`, and `PropertyMock`
- Targets exact API client interactions
- No live cluster required for newly added tests
- Follows existing testing patterns already present in the repository

## Validation

- Standalone OCM tests executed successfully
- Syntax and compile checks passed
- No production code changes

Contributes to #221.