### PR TITLE
fix(k8s): preserve multi-element command arguments for shell pod execution

### DIFF
--- a/src/krkn_lib/k8s/krkn_kubernetes.py
+++ b/src/krkn_lib/k8s/krkn_kubernetes.py
@@ -1178,7 +1178,7 @@ class KrknKubernetes:
                 exec_command = ["bash", "-c"]
             else:
                 exec_command = ["sh", "-c"]
-            exec_command.extend(command)
+            exec_command.append(" ".join(command))
         else:
             exec_command = [base_command]
             exec_command.extend(command)

--- a/src/krkn_lib/tests/test_krkn_kubernetes_exec.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_exec.py
@@ -70,6 +70,18 @@ class KrknKubernetesTestsExec(BaseTest):
 
         try:
             self.lib_k8s.exec_cmd_in_pod(["ls", "-al"], alpine_name, namespace)
+            
+            # Synthetic regression test for argument truncation bug
+            # Currently ["echo", "hello"] executes as `bash/sh -c echo` and drops "hello".
+            # It must preserve and print "hello".
+            result_echo = self.lib_k8s.exec_cmd_in_pod(["echo", "hello"], alpine_name, namespace)
+            self.assertIn("hello", result_echo)
+
+            # Real-world regression test for argument truncation bug
+            # Currently ["ip", "route"] executes as `bash/sh -c ip` and drops "route",
+            # returning the ip usage/help text.
+            result_ip = self.lib_k8s.exec_cmd_in_pod(["ip", "route"], alpine_name, namespace)
+            self.assertNotIn("Usage: ip", result_ip)
         except Exception:
             self.fail()
 


### PR DESCRIPTION
Closes #290 

## Summary

This PR fixes an issue in `exec_cmd_in_pod()` when using the default `bash -c` (or `sh -c`) execution path.

When a multi-element command list is provided without an explicit `base_command`, the implementation currently constructs commands such as:

```text
["bash", "-c", "ip", "route"]
```

However, `bash -c` expects a single command string immediately after `-c`. Any additional elements are interpreted as positional parameters (`$0`, `$1`, ...), rather than arguments to the executed command.

As a result, commands such as:

```python
["ip", "route"]
["echo", "hello"]
```

are effectively executed as:

```text
ip
echo
```

with the remaining arguments ignored.

This change joins the command list into a single command string when using the default shell execution path, while leaving the explicit `base_command` execution path unchanged.

## Testing

Added regression tests covering multi-element command execution through the default shell path.

The tests verify that:

- multi-element command lists preserve their arguments when executed through `bash -c`
- the explicit `base_command` execution path continues to behave as before
- existing single-command shell execution remains unchanged

This change only affects the default shell execution path (`base_command is None`). The explicit `base_command` path is unchanged.