### PR TITLE
test: improve create_job and delete_job exception path coverage (#221)

### DIFF
--- a/src/krkn_lib/tests/test_krkn_kubernetes_create.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_create.py
@@ -13,11 +13,13 @@ import logging
 import tempfile
 import time
 import unittest
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import yaml
 from jinja2 import Environment, FileSystemLoader
 from kubernetes.client import ApiException
 
+from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
 from krkn_lib.tests import BaseTest
 
 
@@ -147,6 +149,43 @@ class KrknKubernetesTestsCreate(BaseTest):
             self.assertIn("Ready", condition_types)
         finally:
             self.pod_delete_queue.put([pod_name, namespace])
+
+
+    def test_create_job_already_exists(self):
+        mock_batch = MagicMock()
+        mock_batch.create_namespaced_job.side_effect = ApiException(status=409)
+        with patch.object(
+            KrknKubernetes,
+            "batch_cli",
+            new_callable=PropertyMock,
+            return_value=mock_batch,
+        ):
+            result = self.lib_k8s.create_job({}, "namespace")
+            self.assertIsNone(result)
+
+    def test_create_job_unexpected_api_exception_returns_none(self):
+        mock_batch = MagicMock()
+        mock_batch.create_namespaced_job.side_effect = ApiException(status=500)
+        with patch.object(
+            KrknKubernetes,
+            "batch_cli",
+            new_callable=PropertyMock,
+            return_value=mock_batch,
+        ):
+            result = self.lib_k8s.create_job({}, "namespace")
+            self.assertIsNone(result)
+
+    def test_create_job_exception_raises(self):
+        mock_batch = MagicMock()
+        mock_batch.create_namespaced_job.side_effect = Exception("mock error")
+        with patch.object(
+            KrknKubernetes,
+            "batch_cli",
+            new_callable=PropertyMock,
+            return_value=mock_batch,
+        ):
+            with self.assertRaises(Exception):
+                self.lib_k8s.create_job({}, "namespace")
 
 
 if __name__ == "__main__":

--- a/src/krkn_lib/tests/test_krkn_kubernetes_delete.py
+++ b/src/krkn_lib/tests/test_krkn_kubernetes_delete.py
@@ -238,5 +238,40 @@ class KrknKubernetesTestsDelete(BaseTest):
                 self.lib_k8s.delete_services("name", "namespace")
 
 
+    def test_delete_job_already_deleted(self):
+        mock_batch = MagicMock()
+        mock_batch.delete_namespaced_job.side_effect = ApiException(status=404)
+        with patch.object(
+            KrknKubernetes,
+            "batch_cli",
+            new_callable=PropertyMock,
+            return_value=mock_batch,
+        ):
+            self.lib_k8s.delete_job("name", "namespace")
+
+    def test_delete_job_unexpected_api_exception_returns_none(self):
+        mock_batch = MagicMock()
+        mock_batch.delete_namespaced_job.side_effect = ApiException(status=500)
+        with patch.object(
+            KrknKubernetes,
+            "batch_cli",
+            new_callable=PropertyMock,
+            return_value=mock_batch,
+        ):
+            self.lib_k8s.delete_job("name", "namespace")
+
+    def test_delete_job_exception_raises(self):
+        mock_batch = MagicMock()
+        mock_batch.delete_namespaced_job.side_effect = Exception("mock error")
+        with patch.object(
+            KrknKubernetes,
+            "batch_cli",
+            new_callable=PropertyMock,
+            return_value=mock_batch,
+        ):
+            with self.assertRaises(Exception):
+                self.lib_k8s.delete_job("name", "namespace")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This PR improves unit test coverage for the `create_job` and `delete_job` helper methods in `krkn_kubernetes.py` as part of #221.

While the existing test suite exercises the successful execution paths, the exception-handling branches were not covered by deterministic unit tests. This change adds isolated tests using mocked Kubernetes clients so those branches can be validated without requiring a running cluster.

### Coverage added

#### `create_job`
- verifies handling of `ApiException(status=409)`
- verifies behavior for other `ApiException` responses
- verifies propagation of unexpected exceptions

#### `delete_job`
- verifies handling of `ApiException(status=404)`
- verifies behavior for other `ApiException` responses
- verifies propagation of unexpected exceptions

The new tests reuse the existing `PropertyMock`-based mocking pattern already used throughout the Kubernetes test suite, keeping the implementation consistent with the surrounding tests.

## Testing

- Added 6 deterministic unit tests
- No production code changes
- Existing testing patterns preserved
- Contributes toward Issue #221 (coverage improvements)