### PR TITLE
fix: pin kubernetes client <36.0.0 to prevent response_type breakage

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2464,4 +2464,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "e933389d3bdc44bc833300653cb46a811fcc4035f830f2145fcdb59c37a47f94"
+content-hash = "f81530d2682b0b60f31b33c58b9a2370a3df5b0fd2d9a3d430644807dbfe6a4d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/redhat-chaos/krkn"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-kubernetes = ">=34.1.0"
+kubernetes = ">=35.0.0,<36.0.0"
 sphinxnotes-markdown-builder="^0.5.6"
 requests = ">=2.32.4"  # Fix CVE GHSA-9hjg-9r4m-mvj7, GHSA-9wx4-h78v-vm56, GHSA-gc5v-m9x4-r6x2
 kubeconfig = "^1.1.1"


### PR DESCRIPTION
## Summary

- Pin `kubernetes` dependency from `>=34.1.0` (unbounded) to `>=35.0.0,<36.0.0`
- Prevents fresh installs from resolving to kubernetes 36.x which renamed `ApiClient.call_api()` parameter `response_type` → `response_types_map`, breaking all 7 call sites in krkn-lib
- Aligns with the constraint already enforced in the krkn repo's `requirements.txt`

## Context

`kubernetes` Python client v36.0.0 (released May 20, 2026) upgraded to OpenAPI Generator v6.6.0 which renamed the `response_type` parameter to `response_types_map` in `ApiClient.call_api()`. Since krkn-lib declares `kubernetes>=34.1.0` with no upper bound, pip resolves to 36.x in any fresh environment, causing:

```
TypeError: ApiClient.call_api() got an unexpected keyword argument 'response_type'
```

**Affected call sites:**
- `krkn_kubernetes.py:3199` — `create_token_for_sa()`
- `krkn_kubernetes.py:3382` — service patching
- `krkn_kubernetes.py:3694` — kubelet proxy node metrics
- `krkn_openshift.py:78,124,160,546` — platform detection, prometheus route

## Related Issues

- Fixes https://github.com/krkn-chaos/krkn-lib/issues/293
- Downstream report: https://github.com/krkn-chaos/krkn/issues/1441

## Test Plan

- [x] Verified `krkn-lib` + `kubernetes==35.0.0` works correctly (token creation succeeds)
- [x] Verified `krkn-lib` + `kubernetes==36.0.2` fails with `TypeError` (confirming the breakage)
- [x] Verified this pin prevents pip from resolving to 36.x


Made with [Cursor](https://cursor.com)